### PR TITLE
Addition of unit tests for FirstStep.js

### DIFF
--- a/tests/unit/FirstStep.spec.js
+++ b/tests/unit/FirstStep.spec.js
@@ -1,0 +1,79 @@
+import { mount } from "@vue/test-utils";
+import FirstStep from "@/Components/FirstStep.vue";
+
+describe("FirstStep.vue", () => {
+    const wrapper = mount(FirstStep);
+    it("Has the main div tag", () => {
+        expect(wrapper.contains(".step-content")).toBe(true);
+    });
+
+    it("renders without any errors", () => {
+        expect(wrapper.isVueInstance()).toBeTruthy();
+    });
+
+    it("Checks if the cardtext function return the correct answer when selected is true", () => {
+        wrapper.setProps({
+            selected: true
+        });
+
+        expect(wrapper.vm.cardText).toBe("stepper.FS.selected");
+    });
+
+    it("Checks if the cardtext function return the correct answer when selected is false", () => {
+        wrapper.setProps({
+            selected: false
+        });
+
+        expect(wrapper.vm.cardText).toBe("stepper.FS.not-selected");
+    });
+
+    it("Checks if the yesText function returns correct answer", () => {
+        expect(wrapper.vm.yesText).toBe("stepper.FS.selected");
+    });
+
+    it("Checks if the yesText function returns correct answer", () => {
+        expect(wrapper.vm.noText).toBe("stepper.FS.not-selected");
+    });
+
+    it("Checks if the yesSelected function returns the correct boolean when selected is true", () => {
+        wrapper.setProps({
+            selected: true
+        });
+        expect(wrapper.vm.yesSelected).toBe("selected");
+    });
+
+    it("Checks if the yesSelected function returns the correct boolean when selected is false", () => {
+        wrapper.setProps({
+            selected: false
+        });
+        expect(wrapper.vm.yesSelected).toBe("not-selected");
+    });
+
+    it("Checks if the get function in radio returns the correct value when selected is undefined", () => {
+        wrapper.setProps({
+            selected: undefined
+        });
+        expect(wrapper.vm.radio).toBe(undefined);
+    });
+
+    it("Checks if the get function in radio returns the correct value when selected is yes", () => {
+        wrapper.setData({
+            selected: "yes"
+        });
+        expect(wrapper.vm.radio).toBe("yes");
+    });
+
+    it("Checks if the noSelected function returns the correct boolean when selected is true", () => {
+        wrapper.setProps({
+            selected: true
+        });
+        expect(wrapper.vm.noSelected).toBe("not-selected");
+    });
+
+    it("Checks if the noSelected function returns the correct boolean when selected is false", () => {
+        wrapper.setProps({
+            selected: false
+        });
+        expect(wrapper.vm.noSelected).toBe("selected");
+    });
+});

--- a/tests/unit/FirstStep.spec.js
+++ b/tests/unit/FirstStep.spec.js
@@ -27,11 +27,11 @@ describe("FirstStep.vue", () => {
         expect(wrapper.vm.cardText).toBe("stepper.FS.not-selected");
     });
 
-    it("Checks if the yesText function returns correct answer", () => {
+    it("Checks if the yesText function returns correct answer ", () => {
         expect(wrapper.vm.yesText).toBe("stepper.FS.selected");
     });
 
-    it("Checks if the yesText function returns correct answer", () => {
+    it("Checks if the noText function returns correct answer", () => {
         expect(wrapper.vm.noText).toBe("stepper.FS.not-selected");
     });
 


### PR DESCRIPTION
Fixes #115 

## Description
<!-- Add your description below. -->
Added unit test cases for the component FirstStep.js using Jest

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
