### PR TITLE
Adds unit and e2e tests for Stepper component

### DIFF
--- a/tests/unit/specs/components/Stepper.spec.js
+++ b/tests/unit/specs/components/Stepper.spec.js
@@ -1,0 +1,34 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import Buefy from 'buefy'
+import Vuex from 'vuex'
+import Stepper from '@/components/Stepper'
+
+const localVue = createLocalVue()
+ 
+localVue.use(Vuex)
+localVue.use(Buefy)
+
+describe('Stepper Component Unit Tests', () => {
+    let wrapper,store
+
+    beforeEach(() => {
+
+        store = new Vuex.Store({});
+
+        wrapper = shallowMount(Stepper, {
+            mocks: {
+                $t: key => key
+            }, 
+            store,
+            localVue,    
+        });
+    })
+
+    afterEach(()=> {
+        wrapper.destroy()
+    })
+
+    it('Stepper Component is initially rendered correctly', () =>{
+        expect(wrapper.element).toMatchSnapshot()
+    })
+})

--- a/tests/unit/specs/components/__snapshots__/Stepper.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/Stepper.spec.js.snap
@@ -1,0 +1,136 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Stepper Component Unit Tests Stepper Component is Rendered Correctly 1`] = `
+<div
+  class="stepper-container column"
+>
+  <div
+    class="step-container current enabled"
+  >
+    <div
+      class="step-header"
+    >
+      <h5
+        class="step-title vocab hb h5b"
+      >
+        
+                stepper.FS.question
+            
+      </h5>
+    </div>
+     
+    <firststep-stub
+      status="current"
+      stepid="0"
+    />
+     
+    <nav
+      class="step-navigation"
+    >
+      <!---->
+       
+      <a
+        class="pagination-next disabled"
+        role="button"
+      >
+        stepper.nav.next-label
+      </a>
+    </nav>
+  </div>
+  <div
+    class="step-container inactive enabled"
+  >
+    <div
+      class="step-header"
+    >
+      <h5
+        class="step-title vocab hb h5b"
+      >
+        
+                stepper.BY.heading
+            
+      </h5>
+    </div>
+     
+    <!---->
+     
+    <!---->
+  </div>
+  <div
+    class="step-container inactive enabled"
+  >
+    <div
+      class="step-header"
+    >
+      <h5
+        class="step-title vocab hb h5b"
+      >
+        
+                stepper.NC.heading
+            
+      </h5>
+    </div>
+     
+    <!---->
+     
+    <!---->
+  </div>
+  <div
+    class="step-container inactive enabled"
+  >
+    <div
+      class="step-header"
+    >
+      <h5
+        class="step-title vocab hb h5b"
+      >
+        
+                stepper.ND.heading
+            
+      </h5>
+    </div>
+     
+    <!---->
+     
+    <!---->
+  </div>
+  <div
+    class="step-container inactive enabled"
+  >
+    <div
+      class="step-header"
+    >
+      <h5
+        class="step-title vocab hb h5b"
+      >
+        
+                stepper.SA.heading
+            
+      </h5>
+    </div>
+     
+    <!---->
+     
+    <!---->
+  </div>
+  <div
+    class="step-container inactive enabled"
+  >
+    <div
+      class="step-header"
+    >
+      <h5
+        class="step-title vocab hb h5b"
+      >
+        
+                stepper.AD.heading
+            
+      </h5>
+    </div>
+     
+    <!---->
+     
+    <!---->
+  </div>
+</div>
+`;


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #126 

## Description
- Adds unit and e2e tests for Stepper Component

<!-- Add any other information below or delete the "Other Information" line entirely. -->

## Checklist
- :white_check_mark:  My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- :white_check_mark:  My pull request targets the `master` branch of the repository.
- :white_check_mark: My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- :white_check_mark: I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
