### PR TITLE
Addition of Unit Tests for LicenseDropdown.vue

### DIFF
--- a/src/components/LicenseDropdown.vue
+++ b/src/components/LicenseDropdown.vue
@@ -1,67 +1,69 @@
 <template>
-    <b-field class="license-dropdown">
-        <b-select
-            :placeholder="this.$t('stepper.DD.placeholder')"
-            :value="shortName"
-            @input="setCurrentLicense"
-        >
-            <option
-                v-for="license in licenseList"
-                :key="license"
-                :value="license"
-            >
-                {{ license }}
-            </option>
-        </b-select>
-    </b-field>
+  <b-field class="license-dropdown">
+    <b-select
+      class="select"
+      :placeholder="this.$t('stepper.DD.placeholder')"
+      :value="shortName"
+      @input="setCurrentLicense"
+    >
+      <option
+        class="options"
+        v-for="license in licenseList"
+        :key="license"
+        :value="license"
+      >{{ license }}</option>
+    </b-select>
+  </b-field>
 </template>
 <script>
-import { mapGetters } from 'vuex'
+import { mapGetters } from "vuex";
 
 export default {
-    name: 'SelectedLicenseDropdown',
-    data() {
-        return {
-            licenseList: [
-                'CC0 1.0',
-                'CC BY 4.0',
-                'CC BY-SA 4.0',
-                'CC BY-ND 4.0',
-                'CC BY-NC 4.0',
-                'CC BY-NC-SA 4.0',
-                'CC BY-NC-ND 4.0'
-            ],
-            currentLicense: undefined
-        }
-    },
-    computed: {
-        ...mapGetters(['shortName', 'fullName'])
-    },
-    methods: {
-        setCurrentLicense(currentLicense) {
-            this.$store.commit('updateAttributesFromShort', currentLicense)
-            this.$emit('input')
-            if (process.env.NODE_ENV === 'production') {
-                this.$ga.event({
-                    eventCategory: 'LicenseDropdown',
-                    eventAction: 'licenseSelected',
-                    eventLabel: currentLicense
-                })
-            }
-        }
+  name: "SelectedLicenseDropdown",
+  data() {
+    return {
+      licenseList: [
+        "CC0 1.0",
+        "CC BY 4.0",
+        "CC BY-SA 4.0",
+        "CC BY-ND 4.0",
+        "CC BY-NC 4.0",
+        "CC BY-NC-SA 4.0",
+        "CC BY-NC-ND 4.0"
+      ],
+      currentLicense: undefined
+    };
+  },
+  computed: {
+    ...mapGetters(["shortName", "fullName"])
+  },
+
+  methods: {
+    setCurrentLicense(currentLicense) {
+      this.$store.commit("updateAttributesFromShort", currentLicense);
+      this.$emit("input");
+      if (process.env.NODE_ENV === "production") {
+        this.$ga.event({
+          eventCategory: "LicenseDropdown",
+          eventAction: "licenseSelected",
+          eventLabel: currentLicense
+        });
+      }
     }
-}
+  }
+};
 </script>
 <style lang="scss">
-    .license-dropdown {
-        margin-top: 1rem;
-        .label{
-            font-weight: normal;
-            opacity: 0.8;
-            font-size: 1em;
-        }
-        .select, select {
-            width: 100%;
-        }
-    }
+.license-dropdown {
+  margin-top: 1rem;
+  .label {
+    font-weight: normal;
+    opacity: 0.8;
+    font-size: 1em;
+  }
+  .select,
+  select {
+    width: 100%;
+  }
+}
 </style>

--- a/tests/unit/LicenseDropdown.spec.js
+++ b/tests/unit/LicenseDropdown.spec.js
@@ -1,0 +1,71 @@
+import { mount, createLocalVue, config } from "@vue/test-utils";
+import LicenseDropdown from "@/Components/LicenseDropdown.vue";
+import VueI18n from "vue-i18n";
+import Vuex from "vuex";
+import Buefy from "buefy";
+import { doesNotReject } from "assert";
+
+describe("LicenseDropdown.vue", () => {
+    let wrapper;
+    let getters;
+    let store;
+
+    beforeEach(() => {
+        const localVue = createLocalVue();
+        localVue.use(VueI18n);
+        localVue.use(Vuex);
+        localVue.use(Buefy);
+
+        getters = {
+            shortName: state => {
+                return "foo";
+            },
+            fullName: state => {
+                return "foo-bar";
+            }
+        };
+
+        store = new Vuex.Store({
+            getters
+        });
+
+        const messages = require("@/locales/en.json");
+        const i18n = new VueI18n({
+            locale: "en",
+            fallbackLocale: "en",
+            messages: messages
+        });
+
+        config.mocks.i18n = i18n;
+
+        config.mocks.$t = key => {
+            return i18n.messages[key];
+        };
+        wrapper = mount(LicenseDropdown, {
+            localVue,
+            store
+        });
+    });
+
+    it("Has the main field tag", () => {
+        expect(wrapper.contains(".license-dropdown")).toBe(true);
+    });
+
+    it("Has the option tag", () => {
+        expect(wrapper.contains(".options")).toBe(true);
+    });
+
+    it("should emit input event from setCurrentLicense method", async () => {
+        wrapper.vm.$emit("input");
+        await wrapper.vm.$nextTick();
+        expect(wrapper.emitted().input).toBeTruthy();
+    });
+
+    it("Checks whether select element is getting triggered", () => {
+        wrapper
+            .findAll(".select")
+            .at(0)
+            .trigger("input");
+    });
+    
+});

--- a/tests/unit/LicenseDropdown.spec.js
+++ b/tests/unit/LicenseDropdown.spec.js
@@ -8,6 +8,7 @@ describe("LicenseDropdown.vue", () => {
     let wrapper;
     let getters;
     let store;
+    let state;
 
     beforeEach(() => {
         const localVue = createLocalVue();
@@ -15,28 +16,33 @@ describe("LicenseDropdown.vue", () => {
         localVue.use(Vuex);
         localVue.use(Buefy);
 
-        const language = require("../../src/locales/en.json");
+        getters = {
+            shortName: state => {
+                return "name";
+            },
 
+            fullName: state => {
+                return "fullName";
+            }
+        };
+        store = new Vuex.Store({
+            store,
+            getters
+        });
+        const messages = require("@/locales/en.json");
         const i18n = new VueI18n({
             locale: "en",
             fallbackLocale: "en",
-            messages: language
+            messages: messages
         });
-
-        store = new Vuex.Store({
-            getters
-        });
-
+        config.mocks.i18n = i18n;
+        config.mocks.$t = key => {
+            return i18n.messages[key];
+        };
         wrapper = mount(LicenseDropdown, {
             localVue,
             store
         });
-
-        config.mocks.i18n = i18n;
-
-        config.mocks.$t = key => {
-            return i18n.messages[key];
-        };
     });
 
     it("Has the field tag", () => {

--- a/tests/unit/LicenseDropdown.spec.js
+++ b/tests/unit/LicenseDropdown.spec.js
@@ -3,7 +3,6 @@ import LicenseDropdown from "@/Components/LicenseDropdown.vue";
 import VueI18n from "vue-i18n";
 import Vuex from "vuex";
 import Buefy from "buefy";
-import { doesNotReject } from "assert";
 
 describe("LicenseDropdown.vue", () => {
     let wrapper;
@@ -16,24 +15,21 @@ describe("LicenseDropdown.vue", () => {
         localVue.use(Vuex);
         localVue.use(Buefy);
 
-        getters = {
-            shortName: state => {
-                return "foo";
-            },
-            fullName: state => {
-                return "foo-bar";
-            }
-        };
+        const language = require("../../src/locales/en.json");
+
+        const i18n = new VueI18n({
+            locale: "en",
+            fallbackLocale: "en",
+            messages: language
+        });
 
         store = new Vuex.Store({
             getters
         });
 
-        const messages = require("@/locales/en.json");
-        const i18n = new VueI18n({
-            locale: "en",
-            fallbackLocale: "en",
-            messages: messages
+        wrapper = mount(LicenseDropdown, {
+            localVue,
+            store
         });
 
         config.mocks.i18n = i18n;
@@ -41,13 +37,9 @@ describe("LicenseDropdown.vue", () => {
         config.mocks.$t = key => {
             return i18n.messages[key];
         };
-        wrapper = mount(LicenseDropdown, {
-            localVue,
-            store
-        });
     });
 
-    it("Has the main field tag", () => {
+    it("Has the field tag", () => {
         expect(wrapper.contains(".license-dropdown")).toBe(true);
     });
 
@@ -67,5 +59,4 @@ describe("LicenseDropdown.vue", () => {
             .at(0)
             .trigger("input");
     });
-    
 });


### PR DESCRIPTION
Fixes #120 

## Description
Added unit test cases for the component LicenseDropdown.vue using Jest

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
