### PR TITLE
Fixed the tests of LicenseCode.vue and LicenseDetailsCard.vue

### DIFF
--- a/src/components/HelpSection.vue
+++ b/src/components/HelpSection.vue
@@ -279,12 +279,11 @@ export default {
         clickHandler(modalNumber) {
             this.modals[modalNumber].status = true
             if (process.env.NODE_ENV === 'production') {
-                const Tracked = this.$ga.event({
+                this.$ga.event({
                     eventCategory: 'HelpSection',
                     eventAction: 'clicked',
                     eventLabel: this.modals[modalNumber].title
                 })
-                return Tracked
             }
         }
     }

--- a/tests/e2e/specs/LicenseCode.js
+++ b/tests/e2e/specs/LicenseCode.js
@@ -8,7 +8,7 @@ module.exports = {
             .assert.elementPresent('.pagination-next')
             .click('.pagination-next')
             .assert.elementPresent('.select > select')
-            .click('.select > select')
+            .click('.select')
             .click('option[value="CC BY-SA 4.0"]')
             .assert.elementPresent('.pagination-next')
             .click('.pagination-next')

--- a/tests/e2e/specs/LicenseDetailsCard.js
+++ b/tests/e2e/specs/LicenseDetailsCard.js
@@ -7,8 +7,8 @@ module.exports = {
             .click('.control-label > span')
             .assert.elementPresent('.pagination-next')
             .click('.pagination-next')
-            .assert.elementPresent('.select > select')
-            .click('.select > select')
+            .assert.elementPresent('.select')
+            .click('.select')
             .click('option[value="CC BY-SA 4.0"]')
             .assert.elementPresent('.selected-license-card')
     },


### PR DESCRIPTION
## Fixes
Fixes #153 by @obulat and removes to return the tracked object

## Description
The e2e tests of `LicenseCode.vue` and `LicenseDetailsCard.vue` started to break because of some click handler error this `PR` fixes them. Also since the $ga was removed from the tests of `Helpsection.vue` I removed the modifications that I did to the `clickHandler` function to return the object which I used to test it. At this point when I ran npm run test all the unit and e2e tests were passing

## Screenshots

---

### Screenshot after the completion of tests
![license2e](https://user-images.githubusercontent.com/43946715/78341255-00224e00-75b5-11ea-8ae0-df6211b88296.png)

---

### Unit tests screenshot with Helpsection highlighted
![helpe2e](https://user-images.githubusercontent.com/43946715/78341349-2ba53880-75b5-11ea-9879-e23dfe72d050.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and me
    have the right to submit it under the open-source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open-source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
