### PR TITLE
Fix Modal positioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1177,6 +1177,14 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@linusborg/vue-simple-portal": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@linusborg/vue-simple-portal/-/vue-simple-portal-0.1.4.tgz",
+      "integrity": "sha512-vYeWYIT9RQ+Lyg6SECPf5+rMeqni7QfXVT/srPkK5NqbpKhppLtkBsPo+VlP61ZecsS1fQQxlfu6Fng/eNukQQ==",
+      "requires": {
+        "nanoid": "^2.0.1"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -10938,6 +10946,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true
+    },
+    "nanoid": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "@fortawesome/free-brands-svg-icons": "^5.12.0",
         "@fortawesome/free-solid-svg-icons": "^5.12.0",
         "@fortawesome/vue-fontawesome": "^0.1.9",
+        "@linusborg/vue-simple-portal": "^0.1.4",
         "@sentry/browser": "^5.12.5",
         "@sentry/integrations": "^5.12.5",
         "buefy": "^0.8.8",

--- a/src/components/HelpSection.vue
+++ b/src/components/HelpSection.vue
@@ -17,212 +17,225 @@
                 </a>
             </li>
         </ul>
-        <b-modal :active.sync="modals[1].status">
-            <header class="modal-card-head">
-                <p
-                    class="modal-card-title modal-title"
-                    v-html="this.$t('help.what-are-cc-licenses.heading')"
-                />
-            </header>
-            <section class="modal-card-body">
-                <article
-                    class="help-text"
-                    v-html="this.$t('help.what-are-cc-licenses.text')"
-                />
-                <footer class="modal-card-foot">
-                    <p v-html="this.$t('help.what-are-cc-licenses.footer')" />
-                </footer>
-            </section>
-        </b-modal>
-        <b-modal :active.sync="modals[2].status">
-            <header class="modal-card-head">
-                <p class="modal-card-title modal-title">
-                    {{ $t('help.how-licenses-work.heading') }}
-                </p>
-            </header>
-            <section class="modal-card-body">
-                <article v-html="this.$t('help.how-licenses-work.text')" />
-                <footer
-                    class="modal-card-foot"
-                    v-html="this.$t('help.how-licenses-work.footer')"
-                />
-            </section>
-        </b-modal>
-        <b-modal :active.sync="modals[3].status">
-            <header class="modal-card-head">
-                <p class="modal-card-title modal-title">
-                    {{ $t('help.what-icons-mean.heading') }}
-                </p>
-            </header>
-            <section class="modal-card-body">
-                <article v-html="this.$t('help.what-icons-mean.text')" />
-                <div class="columns">
-                    <div class="column is-half top-bottom-paddingless">
-                        <div class="edu-icons-section">
-                            <div class="edu-icons-title-section is-gapless">
-                                <img src="../assets/license-icons/cc-by_icon.svg">
-                                <div class="icon-title">
-                                    <b>{{ $t('help.what-icons-mean.BY.long-name') }}</b>
-                                    <p class="help">
-                                        {{ $t('help.what-icons-mean.BY.short-name') }}
-                                    </p>
+        <Portal selector="#portal-target">
+            <b-modal :active.sync="modals[1].status">
+                <header class="modal-card-head">
+                    <p
+                        class="modal-card-title modal-title"
+                        v-html="this.$t('help.what-are-cc-licenses.heading')"
+                    />
+                </header>
+                <section class="modal-card-body">
+                    <article
+                        class="help-text"
+                        v-html="this.$t('help.what-are-cc-licenses.text')"
+                    />
+                    <footer class="modal-card-foot">
+                        <p v-html="this.$t('help.what-are-cc-licenses.footer')" />
+                    </footer>
+                </section>
+            </b-modal>
+        </Portal>
+        <Portal selector="#portal-target">
+            <b-modal :active.sync="modals[2].status">
+                <header class="modal-card-head">
+                    <p class="modal-card-title modal-title">
+                        {{ $t('help.how-licenses-work.heading') }}
+                    </p>
+                </header>
+                <section class="modal-card-body">
+                    <article v-html="this.$t('help.how-licenses-work.text')" />
+                    <footer
+                        class="modal-card-foot"
+                        v-html="this.$t('help.how-licenses-work.footer')"
+                    />
+                </section>
+            </b-modal>
+        </Portal>
+        <Portal selector="#portal-target">
+            <b-modal :active.sync="modals[3].status">
+                <header class="modal-card-head">
+                    <p class="modal-card-title modal-title">
+                        {{ $t('help.what-icons-mean.heading') }}
+                    </p>
+                </header>
+                <section class="modal-card-body">
+                    <article v-html="this.$t('help.what-icons-mean.text')" />
+                    <div class="columns">
+                        <div class="column is-half top-bottom-paddingless">
+                            <div class="edu-icons-section">
+                                <div class="edu-icons-title-section is-gapless">
+                                    <img src="../assets/license-icons/cc-by_icon.svg">
+                                    <div class="icon-title">
+                                        <b>{{ $t('help.what-icons-mean.BY.long-name') }}</b>
+                                        <p class="help">
+                                            {{ $t('help.what-icons-mean.BY.short-name') }}
+                                        </p>
+                                    </div>
                                 </div>
+                                <p>
+                                    {{ $t('help.what-icons-mean.BY.text') }}
+                                </p>
                             </div>
-                            <p>
-                                {{ $t('help.what-icons-mean.BY.text') }}
-                            </p>
+                            <div class="edu-icons-section is-gapless">
+                                <div class="edu-icons-title-section">
+                                    <img src="../assets/license-icons/cc-nd_icon.svg">
+                                    <div class="icon-title">
+                                        <b>{{ $t('help.what-icons-mean.ND.long-name') }}</b>
+                                        <p class="help">
+                                            {{ $t('help.what-icons-mean.ND.short-name') }}
+                                        </p>
+                                    </div>
+                                </div>
+                                <p>
+                                    {{ $t('help.what-icons-mean.ND.text') }}
+                                </p>
+                            </div>
                         </div>
-                        <div class="edu-icons-section is-gapless">
-                            <div class="edu-icons-title-section">
-                                <img src="../assets/license-icons/cc-nd_icon.svg">
-                                <div class="icon-title">
-                                    <b>{{ $t('help.what-icons-mean.ND.long-name') }}</b>
-                                    <p class="help">
-                                        {{ $t('help.what-icons-mean.ND.short-name') }}
-                                    </p>
+                        <div class="column is-half top-bottom-paddingless">
+                            <div class="edu-icons-section is-gapless">
+                                <div class="edu-icons-title-section">
+                                    <img
+                                        class="icon-img"
+                                        src="../assets/license-icons/cc-nc_icon.svg"
+                                    >
+                                    <div class="icon-title">
+                                        <b>{{ $t('help.what-icons-mean.NC.long-name') }}</b>
+                                        <p class="help">
+                                            {{ $t('help.what-icons-mean.NC.short-name') }}
+                                        </p>
+                                    </div>
                                 </div>
+                                <div v-html="this.$t('help.what-icons-mean.NC.text')" />
                             </div>
-                            <p>
-                                {{ $t('help.what-icons-mean.ND.text') }}
-                            </p>
+                            <div class="edu-icons-section">
+                                <div class="edu-icons-title-section is-gapless">
+                                    <img src="../assets/license-icons/cc-sa_icon.svg">
+                                    <div class="icon-title">
+                                        <b>{{ $t('help.what-icons-mean.SA.long-name') }}</b>
+                                        <p class="help">
+                                            {{ $t('help.what-icons-mean.SA.short-name') }}
+                                        </p>
+                                    </div>
+                                </div>
+                                <p>
+                                    {{ $t('help.what-icons-mean.SA.text') }}
+                                </p>
+                            </div>
                         </div>
                     </div>
-                    <div class="column is-half top-bottom-paddingless">
-                        <div class="edu-icons-section is-gapless">
-                            <div class="edu-icons-title-section">
-                                <img
-                                    class="icon-img"
-                                    src="../assets/license-icons/cc-nc_icon.svg"
-                                >
-                                <div class="icon-title">
-                                    <b>{{ $t('help.what-icons-mean.NC.long-name') }}</b>
-                                    <p class="help">
-                                        {{ $t('help.what-icons-mean.NC.short-name') }}
-                                    </p>
-                                </div>
-                            </div>
-                            <div v-html="this.$t('help.what-icons-mean.NC.text')" />
+                </section>
+            </b-modal>
+        </Portal>
+        <Portal selector="#portal-target">
+            <b-modal :active.sync="modals[4].status">
+                <header class="modal-card-head">
+                    <p class="modal-card-title modal-title">
+                        {{ $t('help.considerations-before-licensing.heading') }}
+                    </p>
+                </header>
+                <section class="modal-card-body">
+                    <article v-html="this.$t('help.considerations-before-licensing.text')" />
+                    <footer class="modal-card-foot">
+                        <p v-html="this.$t('help.considerations-before-licensing.footer')" />
+                    </footer>
+                </section>
+            </b-modal>
+            <b-modal :active.sync="modals[5].status">
+                <header class="modal-card-head">
+                    <p class="modal-card-title modal-title">
+                        {{ $t('help.how-formally-license.heading') }}
+                    </p>
+                </header>
+                <section class="modal-card-body">
+                    <article v-html="this.$t('help.how-formally-license.text')" />
+                </section>
+            </b-modal>
+            <b-modal :active.sync="modals[6].status">
+                <header class="modal-card-head">
+                    <p class="modal-card-title modal-title">
+                        {{ $t('help.six-cc-licenses.heading') }}
+                    </p>
+                </header>
+                <section class="modal-card-body">
+                    <div class="columns">
+                        <div class="column is-two-thirds">
+                            <article
+                                v-html="this.$t('help.six-cc-licenses.text')"
+                            />
                         </div>
-                        <div class="edu-icons-section">
-                            <div class="edu-icons-title-section is-gapless">
-                                <img src="../assets/license-icons/cc-sa_icon.svg">
-                                <div class="icon-title">
-                                    <b>{{ $t('help.what-icons-mean.SA.long-name') }}</b>
-                                    <p class="help">
-                                        {{ $t('help.what-icons-mean.SA.short-name') }}
-                                    </p>
-                                </div>
-                            </div>
-                            <p>
-                                {{ $t('help.what-icons-mean.SA.text') }}
-                            </p>
+                        <div class="column">
+                            <img src="../assets/license-openness-scale.png">
                         </div>
                     </div>
-                </div>
-            </section>
-        </b-modal>
-        <b-modal :active.sync="modals[4].status">
-            <header class="modal-card-head">
-                <p class="modal-card-title modal-title">
-                    {{ $t('help.considerations-before-licensing.heading') }}
-                </p>
-            </header>
-            <section class="modal-card-body">
-                <article v-html="this.$t('help.considerations-before-licensing.text')" />
-                <footer class="modal-card-foot">
-                    <p v-html="this.$t('help.considerations-before-licensing.footer')" />
-                </footer>
-            </section>
-        </b-modal>
-        <b-modal :active.sync="modals[5].status">
-            <header class="modal-card-head">
-                <p class="modal-card-title modal-title">
-                    {{ $t('help.how-formally-license.heading') }}
-                </p>
-            </header>
-            <section class="modal-card-body">
-                <article v-html="this.$t('help.how-formally-license.text')" />
-            </section>
-        </b-modal>
-        <b-modal :active.sync="modals[6].status">
-            <header class="modal-card-head">
-                <p class="modal-card-title modal-title">
-                    {{ $t('help.six-cc-licenses.heading') }}
-                </p>
-            </header>
-            <section class="modal-card-body">
-                <div class="columns">
-                    <div class="column is-two-thirds">
-                        <article
-                            v-html="this.$t('help.six-cc-licenses.text')"
-                        />
-                    </div>
-                    <div class="column">
-                        <img src="../assets/license-openness-scale.png">
-                    </div>
-                </div>
 
+                    <footer class="modal-card-foot">
+                        <p v-html="this.$t('help.six-cc-licenses.footer')" />
+                    </footer>
+                </section>
+            </b-modal>
+        </Portal>
+        <Portal selector="#portal-target">
+            <b-modal :active.sync="modals[7].status">
+                <header class="modal-card-head">
+                    <p class="modal-card-title modal-title">
+                        {{ $t('help.how-licenses-communicated.heading') }}
+                    </p>
+                </header>
+                <section class="modal-card-body">
+                    <p v-html="this.$t('help.how-licenses-communicated.text')" />
+                    <table class="table is-hoverable is-fullwidth help-section__table">
+                        <tbody>
+                            <tr>
+                                <th>{{ $t('help.how-licenses-communicated.full-name') }}</th>
+                                <td>{{ $t('help.how-licenses-communicated.CC-BY-NC') }}</td>
+                            </tr>
+                            <tr>
+                                <th>{{ $t('help.how-licenses-communicated.short-name') }}</th>
+                                <td>CC BY-NC</td>
+                            </tr>
+                            <tr>
+                                <th>{{ $t('help.how-licenses-communicated.license-icons') }}</th>
+                                <td><LicenseIcons :icons-arr="['by', 'nc']" /></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
+            </b-modal>
+        </Portal>
+        <Portal selector="#portal-target">
+            <b-modal :active.sync="modals[8].status">
+                <header class="modal-card-head">
+                    <p class="modal-card-title modal-title">
+                        {{ $t('help.what-free-culture-license.heading') }}
+                    </p>
+                </header>
+                <section class="modal-card-body">
+                    <p v-html="this.$t('help.what-free-culture-license.text')" />
+                </section>
                 <footer class="modal-card-foot">
-                    <p v-html="this.$t('help.six-cc-licenses.footer')" />
+                    <p v-html="this.$t('help.what-free-culture-license.footer')" />
                 </footer>
-            </section>
-        </b-modal>
-        <b-modal :active.sync="modals[7].status">
-            <header class="modal-card-head">
-                <p class="modal-card-title modal-title">
-                    {{ $t('help.how-licenses-communicated.heading') }}
-                </p>
-            </header>
-            <section class="modal-card-body">
-                <p v-html="this.$t('help.how-licenses-communicated.text')" />
-                <table class="table is-hoverable is-fullwidth help-section__table">
-                    <tbody>
-                        <tr>
-                            <th>{{ $t('help.how-licenses-communicated.full-name') }}</th>
-                            <td>{{ $t('help.how-licenses-communicated.CC-BY-NC') }}</td>
-                        </tr>
-                        <tr>
-                            <th>{{ $t('help.how-licenses-communicated.short-name') }}</th>
-                            <td>CC BY-NC</td>
-                        </tr>
-                        <tr>
-                            <th>{{ $t('help.how-licenses-communicated.license-icons') }}</th>
-                            <td><LicenseIcons :icons-arr="['by', 'nc']" /></td>
-                        </tr>
-                    </tbody>
-                </table>
-            </section>
-        </b-modal>
-        <b-modal :active.sync="modals[8].status">
-            <header class="modal-card-head">
-                <p class="modal-card-title modal-title">
-                    {{ $t('help.what-free-culture-license.heading') }}
-                </p>
-            </header>
-            <section class="modal-card-body">
-                <p v-html="this.$t('help.what-free-culture-license.text')" />
-            </section>
-            <footer class="modal-card-foot">
-                <p v-html="this.$t('help.what-free-culture-license.footer')" />
-            </footer>
-        </b-modal>
-        <b-modal :active.sync="modals[9].status">
-            <header class="modal-card-head">
-                <p class="modal-card-title modal-title">
-                    {{ $t('help.look-earlier-license-ver.heading') }}
-                </p>
-            </header>
-            <section class="modal-card-body">
-                <p v-html="this.$t('help.look-earlier-license-ver.text')" />
-            </section>
-        </b-modal>
+            </b-modal>
+            <b-modal :active.sync="modals[9].status">
+                <header class="modal-card-head">
+                    <p class="modal-card-title modal-title">
+                        {{ $t('help.look-earlier-license-ver.heading') }}
+                    </p>
+                </header>
+                <section class="modal-card-body">
+                    <p v-html="this.$t('help.look-earlier-license-ver.text')" />
+                </section>
+            </b-modal>
+        </Portal>
     </div>
 </template>
 <script>
 import LicenseIcons from './LicenseIcons'
+import { Portal } from '@linusborg/vue-simple-portal'
 
 // eslint-disable-next-line
-const ModalForm = {
+    const ModalForm = {
     template: `
         <form action="">
             <div class="modal-card" style="width: auto">
@@ -241,7 +254,8 @@ const ModalForm = {
 }
 export default {
     components: {
-        LicenseIcons
+        LicenseIcons,
+        Portal
     },
     data() {
         return {

--- a/src/components/HelpSection.vue
+++ b/src/components/HelpSection.vue
@@ -30,10 +30,10 @@
                         class="help-text"
                         v-html="this.$t('help.what-are-cc-licenses.text')"
                     />
-                    <footer class="modal-card-foot">
-                        <p v-html="this.$t('help.what-are-cc-licenses.footer')" />
-                    </footer>
                 </section>
+                <footer class="modal-card-foot">
+                    <p v-html="this.$t('help.what-are-cc-licenses.footer')" />
+                </footer>
             </b-modal>
         </Portal>
         <Portal selector="#portal-target">
@@ -45,11 +45,11 @@
                 </header>
                 <section class="modal-card-body">
                     <article v-html="this.$t('help.how-licenses-work.text')" />
-                    <footer
-                        class="modal-card-foot"
-                        v-html="this.$t('help.how-licenses-work.footer')"
-                    />
                 </section>
+                <footer
+                    class="modal-card-foot"
+                    v-html="this.$t('help.how-licenses-work.footer')"
+                />
             </b-modal>
         </Portal>
         <Portal selector="#portal-target">
@@ -136,10 +136,10 @@
                 </header>
                 <section class="modal-card-body">
                     <article v-html="this.$t('help.considerations-before-licensing.text')" />
-                    <footer class="modal-card-foot">
-                        <p v-html="this.$t('help.considerations-before-licensing.footer')" />
-                    </footer>
                 </section>
+                <footer class="modal-card-foot">
+                    <p v-html="this.$t('help.considerations-before-licensing.footer')" />
+                </footer>
             </b-modal>
             <b-modal :active.sync="modals[5].status">
                 <header class="modal-card-head">
@@ -168,11 +168,10 @@
                             <img src="../assets/license-openness-scale.png">
                         </div>
                     </div>
-
-                    <footer class="modal-card-foot">
-                        <p v-html="this.$t('help.six-cc-licenses.footer')" />
-                    </footer>
                 </section>
+                <footer class="modal-card-foot">
+                    <p v-html="this.$t('help.six-cc-licenses.footer')" />
+                </footer>
             </b-modal>
         </Portal>
         <Portal selector="#portal-target">
@@ -234,24 +233,6 @@
 import LicenseIcons from './LicenseIcons'
 import { Portal } from '@linusborg/vue-simple-portal'
 
-// eslint-disable-next-line
-    const ModalForm = {
-    template: `
-        <form action="">
-            <div class="modal-card" style="width: auto">
-                <header class="modal-card-head">
-                    <p class="modal-card-title">Login</p>
-                </header>
-                <section class="modal-card-body">
-
-                </section>
-                <footer class="modal-card-foot">
-                    <button class="button" type="button" @click="$parent.close()">Close</button>
-                </footer>
-            </div>
-        </form>
-    `
-}
 export default {
     components: {
         LicenseIcons,


### PR DESCRIPTION
Modal positioning is affected by its parent elements, so to make it render correctly, vue-simple-portal moves rendered modal html to the bottom of the page.

## Fixes  
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #165 by @obulat and #159 by @SaurabhAgarwala 

## Description
<!-- Concisely describe what the pull request does. -->

Currently, modals are rendered as child elements of help component, which makes them use styling of the parent elements. Because of this, various positioning and z-index problems arise, including the issues mentioned in #165:

- select ::after element is not clickable because it's underneath another element. So, we cannot select a language for the site.

- footer text is visible through the modal.

VueSimplePortal enables us to render the modal html to an element at the bottom of the page, outside other parent elements, and solves these issues.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
![CCZIndexIssueSolvedFooterModal](https://user-images.githubusercontent.com/15233243/82445367-5b4cc900-9aad-11ea-9c61-addc36820e19.png)
## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
