### PR TITLE
Add unit tests for App component

### DIFF
--- a/tests/e2e/specs/LicenseCode.js
+++ b/tests/e2e/specs/LicenseCode.js
@@ -31,7 +31,7 @@ module.exports = {
             })
             .getAttribute('p > span > a:nth-child(4)', 'href', function(result) {
                 const urlString = result.value.split('/').slice(3).join('/')
-                this.assert.equal(urlString, 'licenses/by-sa/4.0/?ref=ccchooser')
+                this.assert.equal(urlString, 'licenses/by-sa/4.0/?ref=chooser-v1')
             })
     },
     'Check if the text is displayed under the print attribution': function(browser) {

--- a/tests/e2e/specs/LicenseDetailsCard.js
+++ b/tests/e2e/specs/LicenseDetailsCard.js
@@ -16,7 +16,7 @@ module.exports = {
         browser
             .assert.elementPresent('a[class="license-name"]')
             .getAttribute('a[class="license-name"]', 'href', function(result) {
-                this.assert.equal(result.value, 'https://creativecommons.org/licenses/by-sa/4.0/?ref=ccchooser')
+                this.assert.equal(result.value, 'https://creativecommons.org/licenses/by-sa/4.0/?ref=chooser-v1')
             })
     }
 }

--- a/tests/unit/specs/components/App.spec.js
+++ b/tests/unit/specs/components/App.spec.js
@@ -1,0 +1,51 @@
+import { shallowMount, createLocalVue, config } from '@vue/test-utils'
+import App from '@/App'
+import Buefy from 'buefy'
+import VueI18n from 'vue-i18n'
+import Vuex from 'vuex'
+import Vue from 'vue'
+import store from '@/store'
+
+describe('App.vue', () => {
+    let wrapper
+    let localVue
+
+    // Always creates a shallow instance of component
+    beforeEach(() => {
+      localVue = createLocalVue()
+      localVue.use(Vuex)
+      localVue.use(Buefy)
+      Vue.use(VueI18n)
+      const messages = require('@/locales/en.json')
+      const i18n = new VueI18n({
+          locale: 'en',
+          fallbackLocale: 'en',
+          messages: messages
+      })
+  
+      config.mocks.i18n = i18n
+  
+      config.mocks.$t = key => {
+          // key is a string (eg. 'stepper.ND.question')
+          // this line converts it into an object reference
+          // eg. messages['stepper.ND.question'] -> messages.stepper.ND.question
+          return key.split('.').reduce((messages, k) => messages[k], i18n.messages)
+      }
+      wrapper = shallowMount(App, {
+          store,
+          localVue
+      })
+      wrapper.vm.$on('input', (newVal) => {
+          wrapper.setProps({ value: newVal })
+      })
+    })
+
+    it('Check if App.vue component renders without any errors', () => {
+        expect(wrapper.isVueInstance()).toBeTruthy()
+    })
+
+    // Snapshot tests
+    it('Check if the App.vue component has the expected UI', () => {
+        expect(wrapper).toMatchSnapshot()
+    })
+})

--- a/tests/unit/specs/components/App.spec.js
+++ b/tests/unit/specs/components/App.spec.js
@@ -12,32 +12,32 @@ describe('App.vue', () => {
 
     // Always creates a shallow instance of component
     beforeEach(() => {
-      localVue = createLocalVue()
-      localVue.use(Vuex)
-      localVue.use(Buefy)
-      Vue.use(VueI18n)
-      const messages = require('@/locales/en.json')
-      const i18n = new VueI18n({
-          locale: 'en',
-          fallbackLocale: 'en',
-          messages: messages
-      })
-  
-      config.mocks.i18n = i18n
-  
-      config.mocks.$t = key => {
-          // key is a string (eg. 'stepper.ND.question')
-          // this line converts it into an object reference
-          // eg. messages['stepper.ND.question'] -> messages.stepper.ND.question
-          return key.split('.').reduce((messages, k) => messages[k], i18n.messages)
-      }
-      wrapper = shallowMount(App, {
-          store,
-          localVue
-      })
-      wrapper.vm.$on('input', (newVal) => {
-          wrapper.setProps({ value: newVal })
-      })
+        localVue = createLocalVue()
+        localVue.use(Vuex)
+        localVue.use(Buefy)
+        Vue.use(VueI18n)
+        const messages = require('@/locales/en.json')
+        const i18n = new VueI18n({
+            locale: 'en',
+            fallbackLocale: 'en',
+            messages: messages
+        })
+
+        config.mocks.i18n = i18n
+
+        config.mocks.$t = key => {
+            // key is a string (eg. 'stepper.ND.question')
+            // this line converts it into an object reference
+            // eg. messages['stepper.ND.question'] -> messages.stepper.ND.question
+            return key.split('.').reduce((messages, k) => messages[k], i18n.messages)
+        }
+        wrapper = shallowMount(App, {
+            store,
+            localVue
+        })
+        wrapper.vm.$on('input', (newVal) => {
+            wrapper.setProps({ value: newVal })
+        })
     })
 
     it('Check if App.vue component renders without any errors', () => {

--- a/tests/unit/specs/components/__snapshots__/App.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/App.spec.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`App.vue Check if the App.vue component has the expected UI 1`] = `
+<div id="app">
+  <header-section-stub></header-section-stub>
+  <div id="site-container" class="container">
+    <div class="page-head">
+      <div class="select-license-column">
+        <h2 class="vocab">
+          SELECT YOUR LICENSE
+        </h2>
+        <p class="stepper-instructions vocab-body body-bigger">
+          Follow the steps to select the appropriate license for your work.
+        </p>
+      </div>
+      <localechooser-stub class="locale-chooser"></localechooser-stub>
+    </div>
+    <div class="columns">
+      <stepper-stub value="0"></stepper-stub>
+      <div class="column">
+        <div class="fixed-right-column">
+          <!---->
+          <!---->
+          <helpsection-stub></helpsection-stub>
+        </div>
+      </div>
+    </div>
+  </div>
+  <footer-section-stub></footer-section-stub>
+</div>
+`;


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #124 by @akmadian 

## Description
<!-- Concisely describe what the pull request does. -->
This PR adds unit tests for the App component. I didn't include any e2e tests because there's really no interactivity with the App component itself.

I couldn't think of many test cases so what I've got now feels somewhat anemic. Please let me know if you can think of any other cases and I'll implement them!

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Run `npm run test`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
