### PR TITLE
Use "property" instead of "rel" where appropriate; fixes #188

### DIFF
--- a/src/components/LicenseCode.vue
+++ b/src/components/LicenseCode.vue
@@ -17,14 +17,14 @@
                     <span v-if="!workTitle">{{ $t('license-use.richtext.workTitle') }}</span>
                     <span
                         v-else
-                        rel="dct:title"
+                        property="dct:title"
                     >
                         {{ workTitle }}
                     </span>
                 </a>
                 <span
                     v-else-if="workTitle"
-                    rel="dct:title"
+                    property="dct:title"
                 >
                     {{ workTitle }}
                 </span>
@@ -100,7 +100,7 @@ export default {
         },
         creatorSpan() {
             if (this.creatorName) {
-                return `<span rel="cc:attributionName">${this.creatorName}</span>`
+                return `<span property="cc:attributionName">${this.creatorName}</span>`
             } else return ''
         },
         creatorName() {

--- a/src/utils/license-utilities.js
+++ b/src/utils/license-utilities.js
@@ -154,7 +154,7 @@ function generateHTML(attributionDetails, shortLicenseName) {
         if (workUrl) {
             dataForHtmlGeneration.workTitle = `<a rel="cc:attributionURL" property="dct:title" href="${workUrl}">${workTitle}</a>`
         } else {
-            dataForHtmlGeneration.workTitle = `<span rel="dct:title">${workTitle}</span>`
+            dataForHtmlGeneration.workTitle = `<span property="dct:title">${workTitle}</span>`
         }
     }
     return dataForHtmlGeneration

--- a/tests/unit/specs/components/LicenseCode.spec.js
+++ b/tests/unit/specs/components/LicenseCode.spec.js
@@ -66,7 +66,7 @@ describe('LicenseCode.vue', () => {
     })
     it('Check if the creatorSpan function returns the correct text', () => {
         state.attributionDetails.creatorName = 'J Doe'
-        expect(wrapper.vm.creatorSpan).toBe('<span rel="cc:attributionName">J Doe</span>')
+        expect(wrapper.vm.creatorSpan).toBe('<span property="cc:attributionName">J Doe</span>')
     })
     it('Check if the creatorName function returns the correct text', () => {
         state.attributionDetails.creatorName = 'J Doe'

--- a/tests/unit/specs/utils/license-uilities.test.js
+++ b/tests/unit/specs/utils/license-uilities.test.js
@@ -373,7 +373,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //     test('creator name', () => {
 //         const attr = { creatorName: 'John' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">John</span>',
+//             creator: '<span property="cc:attributionName">John</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/publicdomain/zero/1.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-cc0_icon.svg" /></a>',
 //             workTitle: ''
@@ -382,7 +382,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //     test('creator name + url', () => {
 //         const attr = { creatorName: 'John', creatorProfileUrl: 'j@doe.com' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">John</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">John</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/publicdomain/zero/1.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-cc0_icon.svg" /></a>',
 //             workTitle: ''
@@ -394,7 +394,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //             creator: '',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/publicdomain/zero/1.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-cc0_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('work title + url', () => {
@@ -403,43 +403,43 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //             creator: '',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/publicdomain/zero/1.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-cc0_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 //     test('creator name; work title', () => {
 //         const attr = { workTitle: 'Foo', creatorName: 'Jane' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">Jane</span>',
+//             creator: '<span property="cc:attributionName">Jane</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/publicdomain/zero/1.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-cc0_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('creator name + url; work title', () => {
 //         const attr = { creatorName: 'Jane', creatorProfileUrl: 'j@doe.com', workTitle: 'Foo' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">Jane</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">Jane</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/publicdomain/zero/1.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-cc0_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('creator name; work title + url', () => {
 //         const attr = { creatorName: 'Jane', workTitle: 'Foo', workUrl: 'www.foo.bar' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">Jane</span>',
+//             creator: '<span property="cc:attributionName">Jane</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/publicdomain/zero/1.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-cc0_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 //     test('creator name + url; work title + url', () => {
 //         const attr = { creatorName: 'Jane', creatorProfileUrl: 'j@doe.com', workTitle: 'Foo', workUrl: 'www.foo.bar' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">Jane</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">Jane</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/publicdomain/zero/1.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-cc0_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 // })
@@ -458,7 +458,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //     test('creator name', () => {
 //         const attr = { creatorName: 'John' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">John</span>',
+//             creator: '<span property="cc:attributionName">John</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /></a>',
 //             workTitle: ''
@@ -467,7 +467,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //     test('creator name + url', () => {
 //         const attr = { creatorName: 'John', creatorProfileUrl: 'j@doe.com' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">John</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">John</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /></a>',
 //             workTitle: ''
@@ -479,7 +479,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //             creator: '',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('work title + url', () => {
@@ -488,43 +488,43 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //             creator: '',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 //     test('creator name; work title', () => {
 //         const attr = { workTitle: 'Foo', creatorName: 'Jane' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">Jane</span>',
+//             creator: '<span property="cc:attributionName">Jane</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('creator name + url; work title', () => {
 //         const attr = { creatorName: 'Jane', creatorProfileUrl: 'j@doe.com', workTitle: 'Foo' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">Jane</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">Jane</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('creator name; work title + url', () => {
 //         const attr = { creatorName: 'Jane', workTitle: 'Foo', workUrl: 'www.foo.bar' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">Jane</span>',
+//             creator: '<span property="cc:attributionName">Jane</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 //     test('creator name + url; work title + url', () => {
 //         const attr = { creatorName: 'Jane', creatorProfileUrl: 'j@doe.com', workTitle: 'Foo', workUrl: 'www.foo.bar' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">Jane</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">Jane</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 // })
@@ -543,7 +543,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //     test('creator name', () => {
 //         const attr = { creatorName: 'John' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">John</span>',
+//             creator: '<span property="cc:attributionName">John</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
 //             workTitle: ''
@@ -552,7 +552,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //     test('creator name + url', () => {
 //         const attr = { creatorName: 'John', creatorProfileUrl: 'j@doe.com' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">John</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">John</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
 //             workTitle: ''
@@ -564,7 +564,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //             creator: '',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('work title + url', () => {
@@ -573,43 +573,43 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //             creator: '',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 //     test('creator name; work title', () => {
 //         const attr = { workTitle: 'Foo', creatorName: 'Jane' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">Jane</span>',
+//             creator: '<span property="cc:attributionName">Jane</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('creator name + url; work title', () => {
 //         const attr = { creatorName: 'Jane', creatorProfileUrl: 'j@doe.com', workTitle: 'Foo' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">Jane</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">Jane</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('creator name; work title + url', () => {
 //         const attr = { creatorName: 'Jane', workTitle: 'Foo', workUrl: 'www.foo.bar' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">Jane</span>',
+//             creator: '<span property="cc:attributionName">Jane</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 //     test('creator name + url; work title + url', () => {
 //         const attr = { creatorName: 'Jane', creatorProfileUrl: 'j@doe.com', workTitle: 'Foo', workUrl: 'www.foo.bar' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">Jane</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">Jane</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 // })
@@ -628,7 +628,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //     test('creator name', () => {
 //         const attr = { creatorName: 'John' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">John</span>',
+//             creator: '<span property="cc:attributionName">John</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /></a>',
 //             workTitle: ''
@@ -637,7 +637,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //     test('creator name + url', () => {
 //         const attr = { creatorName: 'John', creatorProfileUrl: 'j@doe.com' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">John</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">John</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /></a>',
 //             workTitle: ''
@@ -649,7 +649,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //             creator: '',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('work title + url', () => {
@@ -658,43 +658,43 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //             creator: '',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 //     test('creator name; work title', () => {
 //         const attr = { workTitle: 'Foo', creatorName: 'Jane' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">Jane</span>',
+//             creator: '<span property="cc:attributionName">Jane</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('creator name + url; work title', () => {
 //         const attr = { creatorName: 'Jane', creatorProfileUrl: 'j@doe.com', workTitle: 'Foo' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">Jane</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">Jane</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('creator name; work title + url', () => {
 //         const attr = { creatorName: 'Jane', workTitle: 'Foo', workUrl: 'www.foo.bar' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">Jane</span>',
+//             creator: '<span property="cc:attributionName">Jane</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 //     test('creator name + url; work title + url', () => {
 //         const attr = { creatorName: 'Jane', creatorProfileUrl: 'j@doe.com', workTitle: 'Foo', workUrl: 'www.foo.bar' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">Jane</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">Jane</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 // })
@@ -713,7 +713,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //     test('creator name', () => {
 //         const attr = { creatorName: 'John' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">John</span>',
+//             creator: '<span property="cc:attributionName">John</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
 //             workTitle: ''
@@ -722,7 +722,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //     test('creator name + url', () => {
 //         const attr = { creatorName: 'John', creatorProfileUrl: 'j@doe.com' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">John</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">John</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
 //             workTitle: ''
@@ -734,7 +734,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //             creator: '',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('work title + url', () => {
@@ -743,43 +743,43 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //             creator: '',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 //     test('creator name; work title', () => {
 //         const attr = { workTitle: 'Foo', creatorName: 'Jane' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">Jane</span>',
+//             creator: '<span property="cc:attributionName">Jane</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('creator name + url; work title', () => {
 //         const attr = { creatorName: 'Jane', creatorProfileUrl: 'j@doe.com', workTitle: 'Foo' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">Jane</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">Jane</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('creator name; work title + url', () => {
 //         const attr = { creatorName: 'Jane', workTitle: 'Foo', workUrl: 'www.foo.bar' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">Jane</span>',
+//             creator: '<span property="cc:attributionName">Jane</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 //     test('creator name + url; work title + url', () => {
 //         const attr = { creatorName: 'Jane', creatorProfileUrl: 'j@doe.com', workTitle: 'Foo', workUrl: 'www.foo.bar' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">Jane</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">Jane</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-sa/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 // })
@@ -798,7 +798,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //     test('creator name', () => {
 //         const attr = { creatorName: 'John' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">John</span>',
+//             creator: '<span property="cc:attributionName">John</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
 //             workTitle: ''
@@ -807,7 +807,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //     test('creator name + url', () => {
 //         const attr = { creatorName: 'John', creatorProfileUrl: 'j@doe.com' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">John</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">John</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
 //             workTitle: ''
@@ -819,7 +819,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //             creator: '',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('work title + url', () => {
@@ -828,43 +828,43 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //             creator: '',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 //     test('creator name; work title', () => {
 //         const attr = { workTitle: 'Foo', creatorName: 'Jane' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">Jane</span>',
+//             creator: '<span property="cc:attributionName">Jane</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('creator name + url; work title', () => {
 //         const attr = { creatorName: 'Jane', creatorProfileUrl: 'j@doe.com', workTitle: 'Foo' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">Jane</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">Jane</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('creator name; work title + url', () => {
 //         const attr = { creatorName: 'Jane', workTitle: 'Foo', workUrl: 'www.foo.bar' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">Jane</span>',
+//             creator: '<span property="cc:attributionName">Jane</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 //     test('creator name + url; work title + url', () => {
 //         const attr = { creatorName: 'Jane', creatorProfileUrl: 'j@doe.com', workTitle: 'Foo', workUrl: 'www.foo.bar' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">Jane</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">Jane</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 // })
@@ -883,7 +883,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //     test('creator name', () => {
 //         const attr = { creatorName: 'John' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">John</span>',
+//             creator: '<span property="cc:attributionName">John</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
 //             workTitle: ''
@@ -892,7 +892,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //     test('creator name + url', () => {
 //         const attr = { creatorName: 'John', creatorProfileUrl: 'j@doe.com' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">John</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">John</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
 //             workTitle: ''
@@ -904,7 +904,7 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //             creator: '',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('work title + url', () => {
@@ -913,43 +913,43 @@ describe('updateVisibleEnabledStatus', function testUpdateVisibleEnabledStatus()
 //             creator: '',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 //     test('creator name; work title', () => {
 //         const attr = { workTitle: 'Foo', creatorName: 'Jane' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">Jane</span>',
+//             creator: '<span property="cc:attributionName">Jane</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('creator name + url; work title', () => {
 //         const attr = { creatorName: 'Jane', creatorProfileUrl: 'j@doe.com', workTitle: 'Foo' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">Jane</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">Jane</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
-//             workTitle: '<span rel="dct:title">Foo</span>'
+//             workTitle: '<span property="dct:title">Foo</span>'
 //         })
 //     })
 //     test('creator name; work title + url', () => {
 //         const attr = { creatorName: 'Jane', workTitle: 'Foo', workUrl: 'www.foo.bar' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<span rel="cc:attributionName">Jane</span>',
+//             creator: '<span property="cc:attributionName">Jane</span>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 //     test('creator name + url; work title + url', () => {
 //         const attr = { creatorName: 'Jane', creatorProfileUrl: 'j@doe.com', workTitle: 'Foo', workUrl: 'www.foo.bar' }
 //         expect(generateHTML(attr, license)).toEqual({
-//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span rel="cc:attributionName">Jane</span></a>',
+//             creator: '<a rel="cc:attributionURL" href="j@doe.com"><span property="cc:attributionName">Jane</span></a>',
 //             htmlString: '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text">',
 //             licenseIconsLink: '<a href="https://creativecommons.org/licenses/by-nc-nd/4.0"><img style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-by_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" /><img  style="height:22px!important;margin-left: 3px;vertical-align:text-bottom;" src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" /></a>',
-//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span rel="dct:title">Foo</span></a>'
+//             workTitle: '<a rel="cc:attributionURL" href="www.foo.bar"><span property="dct:title">Foo</span></a>'
 //         })
 //     })
 // })


### PR DESCRIPTION
## Fixes

Fixes #188 by @fkohrt

## Description

Replaces all occurrences of the `rel` attribute with `property` where appropriate; i.e. where the inner content of the element is targeted (and not the `href` or `src` as implied by `rel`).

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
