### PR TITLE
added unit test for LicenseDropdown component

### DIFF
--- a/tests/unit/specs/components/LicenseCode.spec.js
+++ b/tests/unit/specs/components/LicenseCode.spec.js
@@ -62,7 +62,6 @@ describe('LicenseCode.vue', () => {
         wrapper.vm.$store.commit('setWorkTitle', TEST_DATA.workTitle)
         wrapper.vm.$store.commit('setCreatorProfileUrl', TEST_DATA.creatorProfileUrl)
         wrapper.vm.$store.commit('setWorkUrl', TEST_DATA.workUrl)
-        console.log(wrapper.html())
         expect(wrapper).toMatchSnapshot()
     })
 })

--- a/tests/unit/specs/components/LicenseDropdown.spec.js
+++ b/tests/unit/specs/components/LicenseDropdown.spec.js
@@ -58,6 +58,12 @@ describe('LicenseDropdown.vue',()=>{
         expect(wrapper.contains('option')).toBe(true)
     })
 
+    it('Checks methods: setCurrentLicense',()=>{
+        const options = wrapper.find('select').findAll('option')
+        options.at(1).setSelected()
+        expect(wrapper.emitted().input).toBeTruthy()
+    })
+
     it('Check if the LicenseDropdown.vue component has the expected UI', () => {
         expect(wrapper).toMatchSnapshot()
     })

--- a/tests/unit/specs/components/LicenseDropdown.spec.js
+++ b/tests/unit/specs/components/LicenseDropdown.spec.js
@@ -1,71 +1,55 @@
-import { mount, createLocalVue, config } from '@vue/test-utils'
+import { createLocalVue, mount } from '@vue/test-utils'
 import LicenseDropdown from '@/components/LicenseDropdown.vue'
 import VueI18n from 'vue-i18n'
 import Buefy from 'buefy'
-import Vuex from 'vuex'
 
-describe('LicenseDropdown.vue',()=>{
+describe('LicenseDropdown.vue', () => {
     let wrapper
     let getters
-    let store
-   
-    beforeEach(()=>{
+    let storeMock
+
+    beforeEach(() => {
         const localVue = createLocalVue()
         localVue.use(VueI18n)
         localVue.use(Buefy)
-        localVue.use(Vuex)
-        getters= {
+
+        getters = {
             shortName: () => {
                 return 'CC BY-SA 4.0'
             },
             fullName: () => {
                 return 'Attribution-ShareAlike 4.0 International'
+            }
+        }
+        storeMock = {
+            commit: jest.fn(),
+            getters: getters
+        }
+
+        const options = {
+            mocks: {
+                $store: storeMock,
+                $t: (key) => key
             },
+            localVue
         }
-        store = new Vuex.Store({
-            getters
-        })
-        const messages = require('@/locales/en.json')
-        const i18n = new VueI18n({
-            locale: 'en',
-            fallbackLocale: 'en',
-            messages: messages,
-            silentTranslationWarn: true
-        })
-
-        config.mocks.i18n = i18n
-
-        config.mocks.i18n.$t = (key) => {
-            return i18n.messages[key]
-        }
-        wrapper = mount(LicenseDropdown, {
-            localVue,
-            store,
-            i18n
-        })
+        wrapper = mount(LicenseDropdown, options)
     })
 
     it('Check if LicenseDropdown.vue component renders without any errors', () => {
         expect(wrapper.isVueInstance()).toBe(true)
     })
-    it('Check if b-field tag with class license-dropdown is present in the DOM',()=>{
-        expect(wrapper.contains('.license-dropdown')).toBe(true)
-    })
-    it('Check if select tag is present in the DOM',()=>{
-        expect(wrapper.contains('select')).toBe(true)
-    })
-    it('Check if option tag is present in the DOM',()=>{
-        expect(wrapper.contains('option')).toBe(true)
-    })
 
-    it('Checks methods: setCurrentLicense',()=>{
+    it('Checks methods: setCurrentLicense', () => {
         const options = wrapper.find('select').findAll('option')
         options.at(1).setSelected()
+        const SELECTED_SHORT = options.at(1).text()
+        expect(storeMock.commit).toHaveBeenCalledWith('updateAttributesFromShort', SELECTED_SHORT)
+
         expect(wrapper.emitted().input).toBeTruthy()
     })
 
     it('Check if the LicenseDropdown.vue component has the expected UI', () => {
         expect(wrapper).toMatchSnapshot()
     })
-
 })

--- a/tests/unit/specs/components/LicenseDropdown.spec.js
+++ b/tests/unit/specs/components/LicenseDropdown.spec.js
@@ -1,0 +1,65 @@
+import { mount, createLocalVue, config } from '@vue/test-utils'
+import LicenseDropdown from '@/components/LicenseDropdown.vue'
+import VueI18n from 'vue-i18n'
+import Buefy from 'buefy'
+import Vuex from 'vuex'
+
+describe('LicenseDropdown.vue',()=>{
+    let wrapper
+    let getters
+    let store
+   
+    beforeEach(()=>{
+        const localVue = createLocalVue()
+        localVue.use(VueI18n)
+        localVue.use(Buefy)
+        localVue.use(Vuex)
+        getters= {
+            shortName: () => {
+                return 'CC BY-SA 4.0'
+            },
+            fullName: () => {
+                return 'Attribution-ShareAlike 4.0 International'
+            },
+        }
+        store = new Vuex.Store({
+            getters
+        })
+        const messages = require('@/locales/en.json')
+        const i18n = new VueI18n({
+            locale: 'en',
+            fallbackLocale: 'en',
+            messages: messages,
+            silentTranslationWarn: true
+        })
+
+        config.mocks.i18n = i18n
+
+        config.mocks.i18n.$t = (key) => {
+            return i18n.messages[key]
+        }
+        wrapper = mount(LicenseDropdown, {
+            localVue,
+            store,
+            i18n
+        })
+    })
+
+    it('Check if LicenseDropdown.vue component renders without any errors', () => {
+        expect(wrapper.isVueInstance()).toBe(true)
+    })
+    it('Check if b-field tag with class license-dropdown is present in the DOM',()=>{
+        expect(wrapper.contains('.license-dropdown')).toBe(true)
+    })
+    it('Check if select tag is present in the DOM',()=>{
+        expect(wrapper.contains('select')).toBe(true)
+    })
+    it('Check if option tag is present in the DOM',()=>{
+        expect(wrapper.contains('option')).toBe(true)
+    })
+
+    it('Check if the LicenseDropdown.vue component has the expected UI', () => {
+        expect(wrapper).toMatchSnapshot()
+    })
+
+})

--- a/tests/unit/specs/components/__snapshots__/LicenseDropdown.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/LicenseDropdown.spec.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LicenseDropdown.vue Check if the LicenseDropdown.vue component has the expected UI 1`] = `
+<div class="field license-dropdown">
+  <!---->
+  <div class="control"><span class="select"><select><!----> <option value="CC0 1.0">
+            CC0 1.0
+        </option><option value="CC BY 4.0">
+            CC BY 4.0
+        </option><option value="CC BY-SA 4.0">
+            CC BY-SA 4.0
+        </option><option value="CC BY-ND 4.0">
+            CC BY-ND 4.0
+        </option><option value="CC BY-NC 4.0">
+            CC BY-NC 4.0
+        </option><option value="CC BY-NC-SA 4.0">
+            CC BY-NC-SA 4.0
+        </option><option value="CC BY-NC-ND 4.0">
+            CC BY-NC-ND 4.0
+        </option></select></span>
+    <!---->
+  </div>
+  <!---->
+</div>
+`;

--- a/tests/unit/specs/components/__snapshots__/Stepper.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/Stepper.spec.js.snap
@@ -10,8 +10,7 @@ exports[`Stepper.vue renders correctly has expected UI initially 1`] = `
     </div>
     <firststep-stub stepid="0" status="current"></firststep-stub>
     <nav class="step-navigation">
-      <!----> <a role="button" class="pagination-next disabled">NEXT STEP</a>
-    </nav>
+      <!----> <a role="button" class="pagination-next disabled">NEXT STEP</a></nav>
   </div>
   <div class="step-container BY inactive enabled">
     <div class="step-header">


### PR DESCRIPTION
Signed-off-by: Hrishikesh Agarwal <hrishikeshagarwalv@gmail.com>

## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #120  by @akmadian 

## Description
<!-- Concisely describe what the pull request does. -->
Added unit test for component LicenseDropdown.vue

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Added snapshot test for the component.




## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
