### PR TITLE
Fix copy button in plain text tab under "Use your license"

### DIFF
--- a/src/components/LicenseCopy.vue
+++ b/src/components/LicenseCopy.vue
@@ -21,7 +21,7 @@
                 >
                     <textarea
                         id="attribution-html"
-                        class="textarea"
+                        class="attribution-html-textarea textarea"
                         :value="htmlLicenseParagraph"
                         readonly
                     />
@@ -178,7 +178,7 @@ export default {
         padding-top: 10px;
         padding-bottom: 10px;
     }
-    .generated-html-container textarea {
+    .generated-html-container .attribution-html-textarea.textarea {
         word-break: break-all;
         -ms-word-break: break-all;
         min-height: 60px;

--- a/src/components/LicenseCopy.vue
+++ b/src/components/LicenseCopy.vue
@@ -5,7 +5,10 @@
             class="attribution-tab"
         >
             <b-tab-item :label="this.$t(firstTabLabel)">
-                <div id="attribution-text">
+                <div
+                    id="attribution-text"
+                    class="attribution-text"
+                >
                     <LicenseCode :attribution-type="textAttributionType" />
                 </div>
             </b-tab-item>
@@ -14,8 +17,7 @@
                 :label="this.$t('license-use.html-label')"
             >
                 <div
-                    id="generated-html-container"
-                    class="control"
+                    class="generated-html-container control"
                 >
                     <textarea
                         id="attribution-html"
@@ -165,18 +167,18 @@ export default {
         height: 1.4rem;
     }
 
-    #attribution-text p {
+    .attribution-text p {
         margin-top: 0.5rem;
         margin-bottom: 1rem;
         background-color: #fff;
         padding: 24px 0 0 24px;
         height: 100px;
     }
-    #generated-html-container {
+    .generated-html-container {
         padding-top: 10px;
         padding-bottom: 10px;
     }
-    #generated-html-container textarea {
+    .generated-html-container textarea {
         word-break: break-all;
         -ms-word-break: break-all;
         min-height: 60px;

--- a/src/components/LicenseCopy.vue
+++ b/src/components/LicenseCopy.vue
@@ -6,7 +6,7 @@
         >
             <b-tab-item :label="this.$t(firstTabLabel)">
                 <div
-                    id="attribution-text"
+                    :id="textAttributionId"
                     class="attribution-text"
                 >
                     <LicenseCode :attribution-type="textAttributionType" />
@@ -20,7 +20,7 @@
                     class="generated-html-container control"
                 >
                     <textarea
-                        id="attribution-html"
+                        :id="htmlAttributionId"
                         class="attribution-html-textarea textarea"
                         :value="htmlLicenseParagraph"
                         readonly
@@ -79,6 +79,15 @@ export default {
         },
         firstTabLabel() {
             return this.isWeb ? 'license-use.rich-text-label' : 'license-use.plain-text-label'
+        },
+        attributionIdPrefix() {
+            return this.isWeb ? 'attribution-web-' : 'attribution-print-'
+        },
+        textAttributionId() {
+            return `${this.attributionIdPrefix}-text`
+        },
+        htmlAttributionId() {
+            return `${this.attributionIdPrefix}-html`
         },
         textAttributionType() {
             return this.isWeb ? 'web' : 'print'
@@ -153,7 +162,7 @@ export default {
             e.clearSelection()
         },
         clipboardTarget() {
-            return `#attribution-${this.currentSelection}`
+            return `#${this.attributionIdPrefix}-${this.currentSelection}`
         }
     }
 }


### PR DESCRIPTION
## Fixes
Fixes #206 by @panchovm

## Description
This fixes the copy button in the plain text tab under "Use your license" so it will actually copy the text.

## Technical details
The cause seemed to be the duplicate IDs between the two different tabs. This pull request creates separate IDs for the text elements. In addition, some other duplicate IDs were converted to classes.

This code seems like it could use an overhaul to make the tabs more flexible. The current code relies on a lot of assumptions (like there being only two tabs, Web and print, with the Web tab having two sub-tabs under it).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
