### PR TITLE
Remove ShareAlike when a user selects ND

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -41,9 +41,21 @@ const createStore = (state) => {
             }
         },
         mutations: {
+            /**
+             * Updates current license attributes when user selects radio option.
+             * Edge case: If user selects ND, SA should be set to false
+             * @param state
+             * @param {string} stepName
+             * @param {Boolean} isSelected
+             */
             setSelected(state, { stepName, isSelected }) {
-                // When a Radio button is selected, currentLicenseAttribute 'selected' attribute is updated
-                if (['BY', 'NC', 'ND', 'SA'].indexOf(stepName) > -1) {
+                if (stepName === 'ND' && isSelected && state.currentLicenseAttributes.SA) {
+                    state.currentLicenseAttributes = {
+                        ...state.currentLicenseAttributes,
+                        SA: false,
+                        ND: true
+                    }
+                } else if (['BY', 'NC', 'ND', 'SA'].indexOf(stepName) > -1) {
                     state.currentLicenseAttributes = {
                         ...state.currentLicenseAttributes,
                         [stepName]: isSelected


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #208 by @panchovm

## Description
<!-- Concisely describe what the pull request does. -->
This PR fixes the error when if a user selects ND, SA was not removed. ShareAlike can only be selected when ND is not selected.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
The change was introduced in Vuex mutation.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
