### PR TITLE
Use domain names instead of URLs and harmonize example creator

### DIFF
--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -73,7 +73,7 @@
                 },
                 "creator-profile": {
                     "label": "URL of creator profile",
-                    "placeholder": "www.author.com"
+                    "placeholder": "https://janedoe.com"
                 },
                 "work-title": {
                     "label": "Title of Work",
@@ -81,7 +81,7 @@
                 },
                 "work-url": {
                     "label": "Work URL",
-                    "placeholder": "www.author.com/work.jpg"
+                    "placeholder": "https://janedoe.com/best-photo-ever.jpg"
                 }
             }
         }

--- a/tests/e2e/specs/LicenseCode.js
+++ b/tests/e2e/specs/LicenseCode.js
@@ -17,15 +17,16 @@ module.exports = {
     // 'Check if the links in the license code redirects properly': function(browser) {
     //     browser
     //         .setValue('input[placeholder="Jane Doe"]', 'Jane Doe')
-    //         .setValue('input[placeholder="www.author.com"]', 'www.author.com')
+    //         .setValue('input[placeholder="https://janedoe.com"]', 'https://janedoe.com')
     //         .setValue('input[placeholder="This work"]', 'This work')
-    //         .setValue('input[placeholder="www.author.com/work.jpg"]', 'www.author.com/work.jpg')
+    //         .setValue('input[placeholder="https://janedoe.com/best-photo-ever.jpg"]', 'https://janedoe.com/best-photo-ever.jpg')
     //         .assert.elementPresent('p[class="license-text"] a')
     //         .getAttribute('p > span > a:nth-child(1)', 'href', function(result) {
-    //             this.assert.equal(result.value, 'http://www.author.com/work.jpg')
+    //             this.assert.equal(result.value, 'https://janedoe.com/best-photo-ever.jpg')
+     //         })
     //         })
     //         .getAttribute('p > span > a:nth-child(2)', 'href', function(result) {
-    //             this.assert.equal(result.value, 'http://www.author.com/')
+    //             this.assert.equal(result.value, 'https://janedoe.com')
     //         })
     //         .getAttribute('p > span > a:nth-child(4)', 'href', function(result) {
     //             const urlString = result.value.split('/').slice(3).join('/')
@@ -51,7 +52,7 @@ module.exports = {
     //     browser
     //         .expect.element('#attribution-text > p > span:nth-child(1) > span:nth-child(4)').text.to.equal('CC BY-SA 4.0')
     // },
-    // 'Check if the author-name in plain text is displayed': function(browser) {
+    // 'Check if the creator-name in plain text is displayed': function(browser) {
     //     browser
     //         .expect.element('#attribution-text > p > span:nth-child(1) > span:nth-child(2) > span').text.to.equal('Jane Doe')
     // },

--- a/tests/unit/specs/components/LicenseCode.spec.js
+++ b/tests/unit/specs/components/LicenseCode.spec.js
@@ -7,9 +7,9 @@ import { CCBYAttributes } from '@/utils/license-utilities'
 
 const TEST_DATA = {
     creatorName: 'Jane Doe',
-    creatorProfileUrl: 'www.author.com',
+    creatorProfileUrl: 'https://janedoe.com',
     workTitle: 'My work',
-    workUrl: 'www.author.com/picture.jpg'
+    workUrl: 'https://janedoe.com/best-photo-ever.jpg'
 }
 
 describe('LicenseCode.vue', () => {
@@ -85,7 +85,7 @@ describe('LicenseCode.vue', () => {
         const creatorElement = wrapper.find('[property="cc:attributionName"]')
         expect(Object.keys(creatorElement.attributes()).length).toEqual(3)
         expect(creatorElement.text()).toEqual(TEST_DATA.creatorName)
-        expect(creatorElement.attributes().href).toEqual('http://' + TEST_DATA.creatorProfileUrl)
+        expect(creatorElement.attributes().href).toEqual(TEST_DATA.creatorProfileUrl)
         expect(creatorElement.attributes().rel).toEqual('cc:attributionURL')
         expect(creatorElement.name()).toEqual('a')
     })


### PR DESCRIPTION
## Fixes

Fixes #193 by @fkohrt alongside #200

## Description

Changes `www.author.com` to `https://janedoe.com`

## Tests

I changed the implementation of a test at [`tests/unit/specs/components/LicenseCode.spec.js`](https://github.com/creativecommons/chooser/pull/245/commits/2a4e827962c5ba7a451a782320cc3582f33d27ae#diff-45017824acdbe5c2c634203f4bec474c9089e95e54f2ab86ccd0b3f3521ae0a2L88-R88) so this should be verified to be ok.

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
