### PR TITLE
Improve scrolling

### DIFF
--- a/tests/e2e/page-objects/chooser.js
+++ b/tests/e2e/page-objects/chooser.js
@@ -4,21 +4,23 @@
 
 const stepperCommands = {
     clickYes: function() {
-        this.pause(500)
         this.click('.radio-input[value="yes"]')
+        this.pause(500)
         return this
     },
     clickNo: function() {
-        this.pause(500)
         this.click('.radio-input[value="no"]')
+        this.pause(500)
         return this
     },
     clickNext: function() {
         this.click('.next-button')
+        this.pause(500)
         return this
     },
     clickPrevious: function() {
         this.click('.previous-button')
+        this.pause(500)
         return this
     },
     chooseNo: function() {
@@ -34,7 +36,7 @@ const stepperCommands = {
     clickWaiver: function() {
         this.click('.v-checkbox:first-child')
             .click('.v-checkbox:last-child')
-            .click('.next-button')
+        this.clickNext()
         return this
     },
     selectFromDropdown: function(licenseName) {
@@ -43,6 +45,7 @@ const stepperCommands = {
             .click('.license-dropdown')
             .click(`.license-dropdown option[value="${licenseName}"]`)
             .click('.next-button')
+        this.pause(500)
         return this
     },
     assertStepName: function(stepName) {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #261 by @panchovm

## Description
<!-- Concisely describe what the pull request does. -->
This PR improves automatic scrolling in the Chooser. When the user clicks 'Next' or 'Back', the Chooser automatically scrolls to the next or previous step. When the user clicks 'Done', the Chooser scrolls to the 'Mark your license' section: slower on mobile, and faster on desktop. 
Deployed here: [https://5fdb196f2c7358a2a6e690e3--nostalgic-villani-d2be5c.netlify.app/](https://5fdb196f2c7358a2a6e690e3--nostalgic-villani-d2be5c.netlify.app/)

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
When the user advances in the Stepper by clicking 'Next' button, the Chooser scrolls down to show the next page. Technically, it is implemented as follows: when the `currentStepId` changes, we call `this.$scrollTo()` function to scroll to the top of the previous step, so that both the immediately previous and the active step are displayed on the screen for better context. 

A special case is when the user selects CC0, the Chooser skips three steps (NC, ND, SA) because they are disabled. However, to ensure that the user understands why the Chooser skips so many steps, we keep all three in view, by scrolling to the top of the first disabled step. With this, even in mobile, the top part of the active step (Copyright waiver) is visible. If and when we add opening the Copyright waiver legal text in a separate modal, the whole step will be visible, because there will be no textarea in this step.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
