### PR TITLE
Fix persistence of `CopyrightWaiverStep` checkboxes

### DIFF
--- a/src/components/CopyrightWaiverStep.vue
+++ b/src/components/CopyrightWaiverStep.vue
@@ -1,14 +1,12 @@
 <template>
   <div class="step-actions">
     <v-checkbox
-      name="waive copyright"
       :value="copyright.agreed"
       @input="toggle('agreed')"
     >
       {{ $t('stepper.CW.copyright-waive-agreement') }}
     </v-checkbox>
     <v-checkbox
-      name="confirm waive copyright"
       :value="copyright.confirmed"
       @input="toggle('confirmed')"
     >

--- a/src/components/CopyrightWaiverStep.vue
+++ b/src/components/CopyrightWaiverStep.vue
@@ -35,6 +35,8 @@
   </div>
 </template>
 <script>
+import { mapGetters, mapState } from 'vuex'
+
 export default {
   name: 'CopyrightWaiverStep',
   inheritAttrs: false,

--- a/src/components/CopyrightWaiverStep.vue
+++ b/src/components/CopyrightWaiverStep.vue
@@ -1,9 +1,17 @@
 <template>
   <div class="step-actions">
-    <v-checkbox v-model="copyrightWaiverAgreed">
+    <v-checkbox
+      name="waive copyright"
+      :value="copyright.agreed"
+      @input="toggle('agreed')"
+    >
       {{ $t('stepper.CW.copyright-waive-agreement') }}
     </v-checkbox>
-    <v-checkbox v-model="copyrightWaiverConfirmed">
+    <v-checkbox
+      name="confirm waive copyright"
+      :value="copyright.confirmed"
+      @input="toggle('confirmed')"
+    >
       <i18n
         path="stepper.CW.copyright-waive-confirmation"
         tag="span"
@@ -47,44 +55,23 @@ export default {
   },
   data() {
     return {
-      agreed: false,
-      confirmed: false,
       openModal: false,
     }
   },
   computed: {
-    copyrightWaiverAgreed: {
-      get() {
-        return this.agreed
-      },
-      set() {
-        this.agreed = !this.agreed
-        const payload = { name: this.$props.name, id: this.$props.id }
-        if (this.agreed && this.confirmed) {
-          payload.selected = true
-        } else if (!this.agreed) {
-          payload.selected = undefined
-        }
-        this.$emit('change', payload)
-      },
-    },
-    copyrightWaiverConfirmed: {
-      get() {
-        return this.confirmed
-      },
-      set() {
-        this.confirmed = !this.confirmed
-        const payload = { name: this.$props.name, id: this.$props.id }
-        if (this.agreed && this.confirmed) {
-          payload.selected = true
-        } else if (!this.confirmed) {
-          payload.selected = undefined
-        }
-        this.$emit('change', payload)
-      },
+    ...mapGetters(['allCopyrightClausesChecked']),
+    ...mapState(['copyright']),
+  },
+  watch: {
+    // Watch for all copyright checkboxes being checked and enable the next button if they are
+    allCopyrightClausesChecked(newValue) {
+      this.$emit('change', { name: this.$props.name, id: this.$props.id, selected: newValue ? true : undefined })
     },
   },
   methods: {
+    toggle(key) {
+      this.$store.commit('toggleCopyrightCheckbox', { key })
+    },
     closeModal() {
       this.openModal = false
     },

--- a/src/components/Stepper.vue
+++ b/src/components/Stepper.vue
@@ -11,7 +11,7 @@
         @activate="setActiveStep(step.id)"
       />
       <div
-        v-if="step.status==='active'"
+        v-if="step.status === 'active'"
         class="step-content"
       >
         <component

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -106,6 +106,9 @@ const createStore = (state) => {
       setWorkUrl(state, newName) {
         state.attributionDetails.workUrl = newName
       },
+      setYearOfCreation(state, newName) {
+        state.attributionDetails.yearOfCreation = newName
+      },
       setAttributionType(state, attrType) {
         state.attributionType = attrType
       },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -14,6 +14,24 @@ export const defaultState = {
     yearOfCreation: '',
   },
   attributionType: 'short',
+  copyright: {
+    agreed: false,
+    confirmed: false,
+  },
+}
+
+/**
+ * Updates copyright checkboxes
+ * @param state
+ * @param {Object} payload
+ * @param {string} payload.key The name of the copyright checkbox
+ */
+export const toggleCopyrightCheckbox = (state, { key }) => {
+  state.copyright[key] = !state.copyright[key]
+}
+
+export const allCopyrightClausesChecked = (state) => {
+  return Object.values(state.copyright).every(i => i === true)
 }
 
 const createStore = (state) => {
@@ -23,10 +41,10 @@ const createStore = (state) => {
     getters: {
       isLicenseSelected: state => {
         /**
-                 * By default, all four license attributes are undefined
-                 * As soon as the first attribute(BY) is selected (true/false),
-                 * we can show the recommended license
-                 */
+         * By default, all four license attributes are undefined
+         * As soon as the first attribute(BY) is selected (true/false),
+         * we can show the recommended license
+         */
         return state.currentLicenseAttributes.BY !== undefined
       },
       shortName: state => {
@@ -41,6 +59,7 @@ const createStore = (state) => {
       iconsList: state => {
         return licenseIconsArr(state.currentLicenseAttributes)
       },
+      allCopyrightClausesChecked,
     },
     mutations: {
       /**
@@ -87,15 +106,13 @@ const createStore = (state) => {
       setWorkUrl(state, newName) {
         state.attributionDetails.workUrl = newName
       },
-      setYearOfCreation(state, newName) {
-        state.attributionDetails.yearOfCreation = newName
-      },
       setAttributionType(state, attrType) {
         state.attributionType = attrType
       },
       restoreLicenseAttr(state) {
         state.currentLicenseAttributes = defaultAttributes
       },
+      toggleCopyrightCheckbox,
     },
   })
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -47,8 +47,9 @@ const createStore = (state) => {
              * Updates current license attributes when user selects radio option.
              * Edge case: If user selects ND, SA should be set to false
              * @param state
-             * @param {string} name
-             * @param {Boolean} selected
+             * @param {Object} payload
+             * @param {string} payload.name
+             * @param {Boolean} payload.selected
              */
       setSelected(state, { name, selected }) {
         if (name === 'ND' && selected && state.currentLicenseAttributes.SA) {

--- a/tests/unit/specs/components/CopyrightWaiverStep.spec.js
+++ b/tests/unit/specs/components/CopyrightWaiverStep.spec.js
@@ -24,12 +24,6 @@ describe('Test the functionality of Computed properties', () => {
     wrapper = mount(CopyrightWaiverStep, {
       localVue,
       i18n,
-      data() {
-        return {
-          agreed: false,
-          confirmed: false,
-        }
-      },
       propsData: {
         selected: true,
         status: 'active',
@@ -44,26 +38,6 @@ describe('Test the functionality of Computed properties', () => {
 
   afterEach(() => {
     wrapper.destroy()
-  })
-
-  it('Step Actions block mounted if status is active', () => {
-    wrapper.setProps({ status: 'active', id: 6, name: 'CW' })
-
-    expect(wrapper.find('.step-actions').exists()).toBeTruthy()
-    expect(wrapper.vm.copyrightWaiverAgreed).toBe(false)
-  })
-
-  it('User checks confirmed then checks agreed', () => {
-    const checkbox1 = wrapper.findAll('input[type="checkbox"]').at(1)
-    checkbox1.setChecked()
-
-    const checkbox = wrapper.findAll('input[type="checkbox"]').at(0)
-    checkbox.setChecked()
-    Vue.nextTick()
-    const emittedChange = wrapper.emitted().change[0][0]
-    expect(emittedChange.id).toEqual(6)
-    expect(emittedChange.name).toEqual('CW')
-    expect(wrapper.vm.copyrightWaiverAgreed).toBe(true)
   })
 
   it('User checks agreed and then checks confirmed', () => {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #323 

## Description
<!-- Concisely describe what the pull request does. -->

This PR moves the state of the `CopyrightWaiverStep` checkboxes into Vuex, so they persist when returning to the step from the following steps. This also establishes a pattern for steps with multiple checkboxes that we can use in #315 

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

This PR also models best practices for unit testing in Vue.js, namely, that _simulated user input should be used to test Vue internals._ In this case we're asserting that simulated checking of checkboxes triggers a Vue custom 'change' event in our Step component.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
