### PR TITLE
Sync Community Team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 # be requested for review when someone opens a pull request.
 * @creativecommons/frontend
 * @creativecommons/ct-license-chooser-maintainers
+* @creativecommons/ct-license-chooser-core-committers


### PR DESCRIPTION
This _automated PR_ updates your CODEOWNERS file to mention all GitHub teams associated with Community Team roles.