### PR TITLE
Sync Community Team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # If you want to match two or more code owners with the same pattern, all the
 # code owners must be on the same line. If the code owners are not on the same
 # line, the pattern matches only the last mentioned code owner.
-* @creativecommons/technology @creativecommons/ct-license-chooser-maintainers @creativecommons/ct-license-chooser-core-committers
+* @creativecommons/technology @creativecommons/ct-license-chooser-core-committers @creativecommons/ct-license-chooser-maintainers


### PR DESCRIPTION
This _automated PR_ updates your CODEOWNERS file to mention all GitHub teams associated with Community Team roles.