### PR TITLE
Fixes Improper padding in "Confused? Need Help?" modals #464

### DIFF
--- a/src/components/ChooserModal.vue
+++ b/src/components/ChooserModal.vue
@@ -288,7 +288,7 @@ export default {
 @media only screen and (max-width: 768px) {
   .app-modal {
     .modal {
-      --h-padding: 1rem;
+      --h-padding: 2rem;
       --v-padding: 1.5rem;
       .modal-header {
         padding-top: 1.5rem !important;

--- a/src/components/HelpSection.vue
+++ b/src/components/HelpSection.vue
@@ -78,9 +78,8 @@ export default {
   .help-section .help-links .help-link .help-link-a {
     width: 90%;
   }
+
   
-  a{
-    font-size: 15px;
-  }
+
 }
 </style>

--- a/src/components/HelpSection.vue
+++ b/src/components/HelpSection.vue
@@ -78,8 +78,5 @@ export default {
   .help-section .help-links .help-link .help-link-a {
     width: 90%;
   }
-
-  
-
 }
 </style>

--- a/src/components/HelpSection.vue
+++ b/src/components/HelpSection.vue
@@ -78,5 +78,9 @@ export default {
   .help-section .help-links .help-link .help-link-a {
     width: 90%;
   }
+  
+  a{
+    font-size: 15px;
+  }
 }
 </style>


### PR DESCRIPTION
## Fixes

Fixes #464  by @soustab10 

## Description
Fixed the Improper padding by changing padding in media queries.

## Screenshots
Problem:

![image](https://user-images.githubusercontent.com/65482186/226642977-c5804472-6f8f-43ad-abbf-08b3211be638.png)

Solution:

![image](https://user-images.githubusercontent.com/65482186/226642904-19cdedf3-649d-41c8-8e50-d6ce9e8c155a.png)

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
