### PR TITLE
Fixed overflow issue

### DIFF
--- a/src/components/LicenseUseCard.vue
+++ b/src/components/LicenseUseCard.vue
@@ -106,6 +106,8 @@ export default {
 }
 .attribution-tabs {
   margin-top: 1.25rem;
+  word-wrap: break-word;
+  max-width: 46vw;
   .tabs-content.is-boxed {
     padding: 1.5rem;
     border-bottom: none;
@@ -123,6 +125,7 @@ export default {
   }
   .attribution-tabs {
     margin-top: 1.25rem;
+    max-width: 100vw;
     .tabs-content.is-boxed {
       padding: 1rem;
       border-bottom: none;


### PR DESCRIPTION
## Fixes
Added `word-wrap and max-width` 
Fixed text overflow issue in the rich text box
Fixes #463 by @soustab10 

## Description
My changes breaks the long word in separate parts if the text gets too long and I have fixed a max-width for that component.

## Screenshots
![image](https://user-images.githubusercontent.com/86650576/227317557-7b1d0d7e-cf8f-46cb-b3db-8f29905f6357.png)

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
