### PR TITLE
prevent right column from overflowing and word break on long text in …

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -209,6 +209,9 @@ export default {
   padding-right: var(--outer-padding);
   padding-left: var(--inner-padding);
 }
+.column.right-column{
+  overflow: auto;
+}
 .fixed-right-column {
   position: sticky;
   top: 10px;

--- a/src/components/LicenseText.vue
+++ b/src/components/LicenseText.vue
@@ -145,3 +145,9 @@ export default {
   },
 };
 </script>
+<style lang="scss">
+.license-text{
+  word-wrap: break-word;
+}
+</style>
+


### PR DESCRIPTION
…license-text

## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #463 by @soustab10

## Description
<!-- Concisely describe what the pull request does. -->
![image](https://user-images.githubusercontent.com/60578286/227365898-dbddbfad-5be1-4a4f-9c8e-bd79a18011fb.png)
The root cause for this issue was:
 it was overflowing the right column due to which  part of text above it got hidden
 for that applied overflow auto property

and applied word break property to prevent long word in license-text class which was the only dynamic part

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
NA
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->
SC attached in description 
## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
