### PR TITLE
Fix: Highlight Active Navigation item in navigation bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12568,17 +12568,17 @@
       "dev": true,
       "requires": {
         "chokidar": "^2.0.4",
-        "colors": "latest",
+        "colors": "^1.4.0",
         "connect": "^3.6.6",
-        "cors": "latest",
+        "cors": "^2.8.5",
         "event-stream": "3.3.4",
         "faye-websocket": "0.11.x",
         "http-auth": "3.1.x",
         "morgan": "^1.9.1",
-        "object-assign": "latest",
-        "opn": "latest",
-        "proxy-middleware": "latest",
-        "send": "latest",
+        "object-assign": "^4.1.1",
+        "opn": "^6.0.0",
+        "proxy-middleware": "^0.15.0",
+        "send": "^0.18.0",
         "serve-index": "^1.9.1"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12568,17 +12568,17 @@
       "dev": true,
       "requires": {
         "chokidar": "^2.0.4",
-        "colors": "^1.4.0",
+        "colors": "latest",
         "connect": "^3.6.6",
-        "cors": "^2.8.5",
+        "cors": "latest",
         "event-stream": "3.3.4",
         "faye-websocket": "0.11.x",
         "http-auth": "3.1.x",
         "morgan": "^1.9.1",
-        "object-assign": "^4.1.1",
-        "opn": "^6.0.0",
-        "proxy-middleware": "^0.15.0",
-        "send": "^0.18.0",
+        "object-assign": "latest",
+        "opn": "latest",
+        "proxy-middleware": "latest",
+        "send": "latest",
         "serve-index": "^1.9.1"
       },
       "dependencies": {

--- a/src/components/HeaderSection.vue
+++ b/src/components/HeaderSection.vue
@@ -126,4 +126,3 @@ export default {
   color: #000000;
 }
 </style>
-

--- a/src/components/HeaderSection.vue
+++ b/src/components/HeaderSection.vue
@@ -5,11 +5,11 @@
         <button class="expand-menu">Menu</button>
         <nav class="primary-menu">
             <ul>
-                <li><a href="https://creativecommons.org/about/mission">Who We Are</a></li>
-                <li><a href="https://creativecommons.org/about">What We Do</a></li>
-                <li><a href="https://creativecommons.org/share-your-work">Licenses and Tools</a></li>
-                <li><a href="https://creativecommons.org/blog">Blog</a></li>
-                <li><a href="https://creativecommons.org/about/support-cc/">Support Us</a></li>
+                <li><a :class="{ active: activeLink === 'whoWeAre' }" @click.prevent="setActive('whoWeAre')">Who We Are</a></li>
+                <li><a :class="{ active: activeLink === 'whatWeDo' }" @click.prevent="setActive('whatWeDo')">What We Do</a></li>
+                <li><a :class="{ active: activeLink === 'licensesAndTools' }" @click.prevent="setActive('licensesAndTools')">Licenses and Tools</a></li>
+                <li><a :class="{ active: activeLink === 'blog' }" @click.prevent="setActive('blog')">Blog</a></li>
+                <li><a :class="{ active: activeLink === 'supportUs' }" @click.prevent="setActive('supportUs')">Support Us</a></li>
             </ul>
         </nav>
 
@@ -68,6 +68,18 @@
 <script>
 export default {
   name: 'HeaderSection',
+  data() {
+    return {
+      links: {
+        whoWeAre: 'https://creativecommons.org/about/mission',
+        whatWeDo: 'https://creativecommons.org/about',
+        licensesAndTools: 'https://creativecommons.org/share-your-work',
+        blog: 'https://creativecommons.org/blog',
+        supportUs: 'https://creativecommons.org/about/support-cc/',
+      },
+      activeLink: null,
+    };
+  },
   mounted() {
     const exploreButton = document.querySelector('button.explore');
     const explorePanel = document.querySelector('.explore-panel');
@@ -83,7 +95,35 @@ export default {
       menuPanel.classList.toggle('expand');
     });
   },
+  methods: {
+    setActive(linkName) {
+      this.activeLink = linkName;
+
+      switch (linkName) {
+      case 'whoWeAre':
+        window.location.href = this.links.whoWeAre;
+        break;
+      case 'whatWeDo':
+        window.location.href = this.links.whatWeDo;
+        break;
+      case 'licensesAndTools':
+        window.location.href = this.links.licensesAndTools;
+        break;
+      case 'blog':
+        window.location.href = this.links.blog;
+        break;
+      case 'supportUs':
+        window.location.href = this.links.supportUs;
+        break;
+      }
+    },
+  },
 };
 </script>
 
+<style>
+.active {
+  color: #000000;
+}
+</style>
 


### PR DESCRIPTION
## Fixes creativecommons/vocabulary-theme#67 by @gawandeabhishek

## Description
Fixes the issue where the active section's navigation item was not being highlighted in the navigation bar.

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
