### PR TITLE
Fix bug responsible for showing the wrong completed step caption for BY

### DIFF
--- a/src/components/StepHeader.vue
+++ b/src/components/StepHeader.vue
@@ -44,7 +44,7 @@ export default {
     },
     completedStepCaption() {
       const { name, enabled, selected, disabledDue = null } = this.step;
-      const reversed = name => ['NC', 'ND', 'SA'].indexOf(name) > -1;
+      const reversed = ['NC', 'ND', 'SA'].indexOf(name) > -1;
       let captionKey;
       if (name === 'DD') {
         return this.fullName;


### PR DESCRIPTION
## Description
There was a bug in `StepHeader.vue` because `reversed` was previously defined as a function of `name` but used as if it were the return value of that function. This caused `reversed` to always be truthy, but it should be false for `name == 'BY'. Therefore the completed step caption was incorrectly reversed for BY.

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x ] My commit messages follow [best practices][best_practices].
- [x ] My code follows the established code style of the repository.
- [x ] I added or updated tests for the changes I made (if applicable).
- [x ] I added or updated documentation (if applicable).
- [x ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
