### PR TITLE
[Fix] icon overlay issue of the close button in modal

### DIFF
--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="overlay app-modal" @click.self="$emit('close')">
+    <div class="modal" role="dialog" aria-modal="true">
+      <header v-if="title" class="modal-header">
+        <h3>{{ title }}</h3>
+        <button aria-label="Close" class="close-button" @click="$emit('close')">
+          &times;
+        </button>
+      </header>
+
+      <slot></slot>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AppModal',
+  props: {
+    title: {
+      type: String,
+      default: '',
+    },
+  },
+};
+</script>

--- a/src/components/ChooserModal.vue
+++ b/src/components/ChooserModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <app-modal
+  <AppModal
     v-if="activeModal !== null"
     :title="$t(`help.${modals[activeModal]}.heading`)"
     @close="closeModal"
@@ -119,15 +119,17 @@
         v-html="$t(`help.${modals[activeModal]}.footer`)"
       />
     </section>
-  </app-modal>
+  </AppModal>
 </template>
 
 <script>
 import LicenseIcons from './LicenseIcons';
+import AppModal from './AppModal.vue';
 
 export default {
   name: 'ChooserModal',
   components: {
+    AppModal,
     LicenseIcons,
   },
   props: {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #546 by @akshathere

## Description
<!-- Concisely describe what the pull request does. -->
This PR fixes the issue with the cc logo icon appearing of the close icon on the modals. This is largely a temporary fix.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
The issue was caused by how vocabulary handles the `.icon*` classes, which replaces icons that are not in vocabulary with the cc icon as a default.
From careful inspection of the code, the modal was handled by an `app-modal` component, which was imported from the `@creativecommons/vocabulary-components` npm package. 
Because this package is based on the vue implementation of the legacy vocabulary code, it meant that I couldn't access or edit the source component directly. Hence, I implemented a new modal component, `AppModal` which is the new wrapper for the `ChooserModal` component contents.  This new component now has a corrected implementation of the close icon.

## Additional Notes
I must add that this implementation is temporary, as there is no close icon in the the vocabulary design system yet. A more permanent solution would be to;

1. Update the vocabulary repo to include a close icon
2. Update the version of Vocabulary in this repo to the version with the close icon implemented
3. Implement the close icon as prescribed by the vocabulary guidelines.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
- Run the source code on your local machine.
- Scroll down the the "Confused? Need Help?" section
- Click on any of the questions and observe the modal.
- Run the `docker compose exec chooser-node npm run test` command and observe your terminal and confirm no errors were logged.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
<img width="751" alt="Screenshot 2024-11-05 at 22 22 33" src="https://github.com/user-attachments/assets/3734f522-a99a-45ea-9f9f-9316fa40cb7b">
<img width="889" alt="Screenshot 2024-11-05 at 22 22 44" src="https://github.com/user-attachments/assets/ec36ec97-0256-432a-a5ee-fd1e80bf23d4">


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
