### PR TITLE
Fix semantic conflict in accordion buttons

### DIFF
--- a/src/components/HelpSection.vue
+++ b/src/components/HelpSection.vue
@@ -3,15 +3,104 @@
     <h2 class="title is-3">
       {{ $t('help.heading') }}
     </h2>
-    <ul class="help-links">
-      <li v-for="(modal, idx) in modals" :key="idx" class="help-link">
-        <v-button theme="text" class="help-link-a" @click="clickHandler(idx)">
+    <div class="help-accordion">
+      <div
+        v-for="(modal, idx) in modals"
+        :key="idx"
+        class="help-accordion-item"
+      >
+        <button
+          class="help-accordion-header"
+          :aria-expanded="isAccordionOpen(idx)"
+          @click="toggleAccordion(idx)"
+        >
           {{ $t(`help.${modal}.heading`) }}
-        </v-button>
-      </li>
-    </ul>
+          <span class="chevron" :class="{ rotated: openModal === idx }">
+            ▶
+          </span>
+        </button>
+        <div v-show="openModal === idx" class="help-accordion-content">
+          <!-- Render rich HTML from JSON's text field -->
+          <div v-if="openModal !== 3" v-html="$t(`help.${modal}.text`)"></div>
+
+          <section v-if="openModal === 3">
+            <p>
+              {{ $t('help.what-icons-mean.text') }}
+            </p>
+            <div class="icons-section">
+              <div class="icon-item">
+                <img
+                  src="@creativecommons/cc-assets/icons/cc-by.svg"
+                  :alt="$t('help.what-icons-mean.BY.icon-alt-text')"
+                />
+                <h6 class="b-header">
+                  {{ $t('help.what-icons-mean.BY.long-name') }}
+                </h6>
+                <p class="icon-caption">
+                  {{ $t('help.what-icons-mean.BY.short-name') }}
+                </p>
+                <p class="icon-text">
+                  {{ $t('help.what-icons-mean.BY.text') }}
+                </p>
+              </div>
+              <div class="icon-item">
+                <img
+                  src="@creativecommons/cc-assets/icons/cc-nd.svg"
+                  :alt="$t('help.what-icons-mean.ND.icon-alt-text')"
+                />
+                <h6 class="b-header">
+                  {{ $t('help.what-icons-mean.ND.long-name') }}
+                </h6>
+                <p class="icon-caption">
+                  {{ $t('help.what-icons-mean.ND.short-name') }}
+                </p>
+                <p class="icon-text">
+                  {{ $t('help.what-icons-mean.ND.text') }}
+                </p>
+              </div>
+              <div class="icon-item">
+                <img
+                  src="@creativecommons/cc-assets/icons/cc-nc.svg"
+                  :alt="$t('help.what-icons-mean.NC.icon-alt-text')"
+                />
+                <h6 class="b-header">
+                  {{ $t('help.what-icons-mean.NC.long-name') }}
+                </h6>
+                <p class="icon-caption">
+                  {{ $t('help.what-icons-mean.NC.short-name') }}
+                </p>
+                <p class="icon-text">
+                  {{ $t('help.what-icons-mean.NC.text') }}
+                </p>
+              </div>
+              <div class="icon-item">
+                <img
+                  src="@creativecommons/cc-assets/icons/cc-sa.svg"
+                  :alt="$t('help.what-icons-mean.SA.icon-alt-text')"
+                />
+                <h6 class="b-header">
+                  {{ $t('help.what-icons-mean.SA.long-name') }}
+                </h6>
+                <p class="icon-caption">
+                  {{ $t('help.what-icons-mean.SA.short-name') }}
+                </p>
+                <p class="icon-text">
+                  {{ $t('help.what-icons-mean.SA.text') }}
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <!-- Optional footer if available -->
+          <div v-if="$t(`help.${modal}.footer`)" class="help-footer">
+            {{ $t(`help.${modal}.footer`) }}
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
+
 <script>
 export default {
   data() {
@@ -32,51 +121,94 @@ export default {
     },
   },
   methods: {
-    async clickHandler(modalNumber) {
-      this.$emit('change', modalNumber);
-      this.openModal = parseInt(modalNumber);
-      await this.$nextTick();
-      this.$nextTick(function() {
-        const modalLinks = document.querySelectorAll('.modal a');
-        modalLinks.forEach(function(link) {
-          link.target = '_blank';
-          link.rel = 'noopener noreferrer';
-        });
-      });
+    toggleAccordion(index) {
+      this.openModal = this.openModal === index ? null : index;
+    },
+    isAccordionOpen(index) {
+      return this.openModal === index;
     },
   },
 };
 </script>
+
 <style lang="scss">
 .help-section {
   margin-top: 3rem;
 
-  .help-links {
-    margin-top: 1rem;
+  .help-accordion {
+    .help-accordion-item {
+      border-bottom: 1px solid #dddddd;
 
-    .help-link {
-      margin-bottom: 0.25rem;
-      list-style: disc inside none;
-
-      &::marker {
-        color: #b0b0b0;
-      }
-
-      .help-link-a {
-        color: #c74200;
+      .help-accordion-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+        padding: 0.5rem;
+        background: #f9f9f9;
+        border: none;
+        cursor: pointer;
+        font-size: 1rem;
         font-weight: 600;
+        color: #c74200;
 
         &:hover {
-          text-decoration: underline;
+          background: #f2f2f2;
         }
+
+        .chevron {
+          transition: transform 0.2s ease-in-out;
+
+          &.rotated {
+            transform: rotate(90deg);
+          }
+        }
+      }
+
+      .help-accordion-content {
+        padding: 1rem;
+        background: #ffffff;
+        color: #333333;
+        font-size: 0.9rem;
+        line-height: 1.4;
       }
     }
   }
-}
 
-@media only screen and (max-width: 768px) {
-  .help-section .help-links .help-link .help-link-a {
-    width: 90%;
+  .icons-section {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    row-gap: 2rem;
+    @media only screen and (max-width: 768px) {
+      grid-template-columns: 100%;
+    }
+  }
+
+  .icon-item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto 1fr 1fr;
+    grid-template-areas:
+      'icon title'
+      'icon caption'
+      'text text';
+    column-gap: 1rem;
+    img {
+      grid-area: icon;
+      width: 45px;
+    }
+
+    h6 {
+      grid-area: title;
+    }
+
+    .icon-caption {
+      grid-area: caption;
+    }
+
+    .icon-text {
+      grid-area: text;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Fixes
- Fixes #544

## Description
- In the Choose A License page, there is a section called Confused? Need help? where the elements that look like hyperlinks are actually buttons, which is a UX issue. This PR resolves the problem by making these elements function as accordions, aligning with typical FAQ design practices.

## Technical details
- Replaced the v-btn elements with v-accordion components for better semantic alignment and to resolve the conflict between visual representation (links) and functionality (buttons).
- Ensured the accordion structure allows for expandable/collapsible sections, providing further information in a popup-like behavior when clicked.
- Updated styles to retain the hyperlink-like visual cues while adhering to semantic accuracy.

## Tests
- Verify that the Confused? Need help? section is now rendered as an accordion with proper expand/collapse functionality.
- Ensure that the UX matches typical FAQ design and that there are no regressions in behavior or styling.
- Validate accessibility (a11y) compliance for the updated components.

## Steps to Test:
- Open the application.
- Navigate to the **Choose A License** page and scroll to the **Confused? Need help?** section.
- Interact with the accordion elements:
  - Ensure clicking expands and collapses sections correctly.
  - Confirm the information is displayed as expected.
  - Verify no unexpected navigation occurs.

## Screenshots
-  Before 
![Screenshot 2024-11-25 011444](https://github.com/user-attachments/assets/edc04360-43ab-4615-81ea-fee3b1ebdbd3)

- After
![Screenshot 2024-11-25 011429](https://github.com/user-attachments/assets/8d0c1a2f-b6a4-485e-9c2d-96750cdee17f)
