### PR TITLE
correct `h1` to "Chooser", build out semantic html for "results" area

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -309,11 +309,13 @@
 
     <aside>
         <div id="license-recommendation">
+            <h2>Recommended License</h2>
+
             <article class="license">
 
                 <header>
-                    <h2>CC-BY 4.0</h2>
-                    <h3>Creative Commons Attribution 4.0 International</h3>
+                    <h3>CC-BY 4.0</h3>
+                    <h4>Creative Commons Attribution 4.0 International</h4>
                 </header>
 
                 <div class="description">

--- a/src/index.html
+++ b/src/index.html
@@ -383,5 +383,40 @@
 <script src="vocabulary/js/vocabulary.js"></script>
 <script src="scripts.js"></script>
 
+
+
+
+<template id="results">
+    <div data-v-02ee162d="" class="recommended-card">
+        <h3 data-v-02ee162d="">RECOMMENDED LICENSE</h3>
+        <div data-v-02ee162d="" class="license-short-name"><span data-v-02ee162d="" class="license-icons">
+            <span data-v-a0d4e8a8="" data-v-02ee162d="" class="icon">
+                <img data-v-a0d4e8a8="" width="50" height="50" src="/img/cc-logo.f0ab4ebe.svg">
+            </span>
+            <span data-v-a0d4e8a8="" data-v-02ee162d="" class="icon">
+                <img data-v-a0d4e8a8="" width="50" height="50" src="/img/cc-by.21b728bb.svg">
+            </span>
+        </span>
+            <h4 data-v-02ee162d="" class="b-header"> CC BY 4.0 </h4>
+        </div>
+        <h4 data-v-02ee162d="" class="b-header"> Creative Commons Attribution 4.0 International </h4>
+        <p data-v-02ee162d="" class="license-full-description body-big"> This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes. </p>
+        <section data-v-02ee162d="" class="items-description">
+            <ul data-v-02ee162d="" class="license-list">
+                <span data-v-02ee162d="">
+                <li data-v-02ee162d="" class="license-list-item by">
+                    <span data-v-02ee162d="" class="readable-string">
+                        <span data-v-a0d4e8a8="" data-v-02ee162d="" class="icon">
+                            <img data-v-a0d4e8a8="" width="30" height="30" src="/img/cc-by.21b728bb.svg">
+                        </span>
+                    <span data-v-02ee162d="">
+                        <b data-v-02ee162d="">BY:</b> Credit must be given to you, the creator. 
+                    </span>
+                </span><!----></li></span></ul></section><div data-v-02ee162d="">
+                <a data-v-02ee162d="" href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v1" target="_blank" rel="noopener noreferrer" class="license-deed-link"> See the License Deed <svg data-v-02ee162d="" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="up-right-from-square" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="icon icon-size svg-inline--fa fa-up-right-from-square"><path data-v-02ee162d="" fill="currentColor" d="M352 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L370.7 96 201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L416 141.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6V32c0-17.7-14.3-32-32-32H352zM80 32C35.8 32 0 67.8 0 112V432c0 44.2 35.8 80 80 80H400c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32V432c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16H192c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z" class=""></path></svg></a>
+        </div>
+    </div>
+</template>
+
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -390,10 +390,10 @@
         <p>Except where otherwise <a href="/policies/#license">noted</a>, content on this site is licensed under a <a href="/licenses/by/4.0/">Creative Commons Attribution 4.0 International license</a>. Icons by <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.</p>
 
         <svg>
-            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
         </svg>
         <svg>
-            <use href="../../src/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-by"></use>
         </svg>
     </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -309,9 +309,28 @@
 
     <aside>
         <div id="license-recommendation">
-            <p>[license recommendation info here]</p>
+            <article class="license">
+
+                <header>
+                    <h2>CC-BY 4.0</h2>
+                    <h3>Creative Commons Attribution 4.0 International</h3>
+                </header>
+
+                <div class="description">
+                    <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p>
+                </div>
+
+                <dl class="conditions-definitions">
+                    <dt class="icon-attach cc-by">BY</dt>
+                    <dd>Credit must be given to you, the creator.</dd>
+                </dl>
+
+            </article>
         </div>
-        <p>[attribution info here]</p>
+
+        <div id="attribution-information">
+            <p>[attribution info here]</p>
+        </div>
     </aside>
 
 </div>
@@ -386,7 +405,7 @@
 
 
 
-<template id="results">
+<template id="results-sample">
     <div data-v-02ee162d="" class="recommended-card">
         <h3 data-v-02ee162d="">RECOMMENDED LICENSE</h3>
         <div data-v-02ee162d="" class="license-short-name"><span data-v-02ee162d="" class="license-icons">

--- a/src/index.html
+++ b/src/index.html
@@ -19,7 +19,7 @@
 
 <header>
     <div class="masthead">
-        <h1><a class="identity-logo product" href="#">Vocabulary</a></h1>
+        <h1><a class="identity-logo product" href="#">Chooser</a></h1>
         <button class="expand-menu">Menu</button>
         <nav class="primary-menu" aria-label="Primary navigation">
             <ul>

--- a/src/index.html
+++ b/src/index.html
@@ -327,6 +327,8 @@
                     <dd>Credit must be given to you, the creator.</dd>
                 </dl>
 
+            <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a>
+
             </article>
         </div>
 
@@ -405,38 +407,8 @@
 <script src="scripts.js"></script>
 
 
-
-
-<template id="results-sample">
-    <div data-v-02ee162d="" class="recommended-card">
-        <h3 data-v-02ee162d="">RECOMMENDED LICENSE</h3>
-        <div data-v-02ee162d="" class="license-short-name"><span data-v-02ee162d="" class="license-icons">
-            <span data-v-a0d4e8a8="" data-v-02ee162d="" class="icon">
-                <img data-v-a0d4e8a8="" width="50" height="50" src="/img/cc-logo.f0ab4ebe.svg">
-            </span>
-            <span data-v-a0d4e8a8="" data-v-02ee162d="" class="icon">
-                <img data-v-a0d4e8a8="" width="50" height="50" src="/img/cc-by.21b728bb.svg">
-            </span>
-        </span>
-            <h4 data-v-02ee162d="" class="b-header"> CC BY 4.0 </h4>
-        </div>
-        <h4 data-v-02ee162d="" class="b-header"> Creative Commons Attribution 4.0 International </h4>
-        <p data-v-02ee162d="" class="license-full-description body-big"> This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes. </p>
-        <section data-v-02ee162d="" class="items-description">
-            <ul data-v-02ee162d="" class="license-list">
-                <span data-v-02ee162d="">
-                <li data-v-02ee162d="" class="license-list-item by">
-                    <span data-v-02ee162d="" class="readable-string">
-                        <span data-v-a0d4e8a8="" data-v-02ee162d="" class="icon">
-                            <img data-v-a0d4e8a8="" width="30" height="30" src="/img/cc-by.21b728bb.svg">
-                        </span>
-                    <span data-v-02ee162d="">
-                        <b data-v-02ee162d="">BY:</b> Credit must be given to you, the creator. 
-                    </span>
-                </span><!----></li></span></ul></section><div data-v-02ee162d="">
-                <a data-v-02ee162d="" href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v1" target="_blank" rel="noopener noreferrer" class="license-deed-link"> See the License Deed <svg data-v-02ee162d="" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="up-right-from-square" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="icon icon-size svg-inline--fa fa-up-right-from-square"><path data-v-02ee162d="" fill="currentColor" d="M352 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L370.7 96 201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L416 141.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6V32c0-17.7-14.3-32-32-32H352zM80 32C35.8 32 0 67.8 0 112V432c0 44.2 35.8 80 80 80H400c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32V432c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16H192c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z" class=""></path></svg></a>
-        </div>
-    </div>
+<template id="license">
+    <!-- placeholder for swapping out content later with JS -->
 </template>
 
 </body>

--- a/src/style.css
+++ b/src/style.css
@@ -1,1 +1,18 @@
 @import 'vocabulary/css/vocabulary.css' layer(vocabulary);
+
+
+:root {
+
+    /* localized cc sprite names */
+    --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-by');
+    
+}
+
+.icon-attach.cc-by:before {
+    --icon-sprite: var(--cc-by);
+    /* --icon-sprite-size: 2em; */
+    margin-right: .2em;
+    margin-bottom: -.125em;
+}
+
+

--- a/src/style.css
+++ b/src/style.css
@@ -5,14 +5,12 @@
 
     /* localized cc sprite names */
     --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-by');
-    --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-nc');
-    --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-nd');
-    --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-pd');
-    --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-pdm');
-    --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-sa');
-    --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-zero');
-    
-    
+    --cc-nc: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-nc');
+    --cc-nd: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-nd');
+    --cc-pd: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-pd');
+    --cc-pdm: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-pdm');
+    --cc-sa: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-sa');
+    --cc-zero: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-zero');
 }
 
 .icon-attach.cc-by:before {
@@ -62,4 +60,8 @@
     /* --icon-sprite-size: 2em; */
     margin-right: .2em;
     margin-bottom: -.125em;
+}
+
+dt, dd {
+    display: inline-block;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -5,6 +5,13 @@
 
     /* localized cc sprite names */
     --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-by');
+    --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-nc');
+    --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-nd');
+    --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-pd');
+    --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-pdm');
+    --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-sa');
+    --cc-by: url('/vocabulary/svg/cc/icons/cc-icons.svg#cc-zero');
+    
     
 }
 
@@ -15,4 +22,44 @@
     margin-bottom: -.125em;
 }
 
+.icon-attach.cc-nc:before {
+    --icon-sprite: var(--cc-nc);
+    /* --icon-sprite-size: 2em; */
+    margin-right: .2em;
+    margin-bottom: -.125em;
+}
 
+.icon-attach.cc-nd:before {
+    --icon-sprite: var(--cc-nd);
+    /* --icon-sprite-size: 2em; */
+    margin-right: .2em;
+    margin-bottom: -.125em;
+}
+
+.icon-attach.cc-pd:before {
+    --icon-sprite: var(--cc-pd);
+    /* --icon-sprite-size: 2em; */
+    margin-right: .2em;
+    margin-bottom: -.125em;
+}
+
+.icon-attach.cc-pdm:before {
+    --icon-sprite: var(--cc-pdm);
+    /* --icon-sprite-size: 2em; */
+    margin-right: .2em;
+    margin-bottom: -.125em;
+}
+
+.icon-attach.cc-sa:before {
+    --icon-sprite: var(--cc-sa);
+    /* --icon-sprite-size: 2em; */
+    margin-right: .2em;
+    margin-bottom: -.125em;
+}
+
+.icon-attach.cc-zero:before {
+    --icon-sprite: var(--cc-zero);
+    /* --icon-sprite-size: 2em; */
+    margin-right: .2em;
+    margin-bottom: -.125em;
+}


### PR DESCRIPTION
## Description
* defines a basic semantic markup "component" for `license recommendation`, and a general `license` sub-component within, with appropriate sub-elements. 
* creates a localized implementation of the cc license icons for use with the icon-attach helper class with the relevant cc-icons.svg sprite sheet.
* corrects the page title
* corrects the path for the page-level cc license icons (they now load instead of 404)
* zeros out the `<template>` for now to be used later with JS

## Technical details
Things remain messy and unfinished, but we now have a basic area within which to populate a relevant license recommendation when JS functionality is added later.

I tried to keep the semantics simple, but I think it might get improvements later. It made sense that the conditions definitions broken down within the various licenses was best served as a definition list, rather than just a regular `ol`. We are, just a tad bit being mushy with semantics since there's certainly an argument around "one item does not a list make", but I think it's close enough in spirit to be fine when there's only one item, to gain the added semantics when it is not.

Next up will be the "How to mark your work for attribution" area markup.


## Screenshots
![license-rec-area](https://github.com/user-attachments/assets/66cd1de6-8bfc-4f04-a129-b3d5d2ac09e5)

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
