### PR TITLE
setup baseline file for stepper logic, hide/show steps, adds minimal license rec capacity

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -18,5 +18,28 @@ let rawStatePathRoutes = [
     'do-you-know-which-license-you-need/no/require-attribution/no/waive-your-copyright+waive+read/(attribution-details)&license=cc-0'
 ];
 
+// function to parse and build state.possibilities
 
-// stepper logic here
+// function to track state.parts
+// [T]: should this be a part of state.current
+// as in: state.current.parts ?
+
+// function to update and track state.current
+// this is a full combo of all set state.parts
+
+// function to compare state.possibilities to state.current, 
+// determine if valid license, or error
+
+// function to set state.props
+// including setting state.props.license (if valid)
+
+// stepper logic here for what parts are displayed,
+// if valid license from state.parts and/or state.current
+
+// function to render license recommendation,
+// if valid license from state.parts and/or state.current
+
+// function to render mark your work, from attribution fields
+// if valid license from state.parts and/or state.current
+
+// function to handle error state

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -18,13 +18,56 @@ let rawStatePathRoutes = [
     'do-you-know-which-license-you-need/no/require-attribution/no/waive-your-copyright+waive+read/(attribution-details)&license=cc-0'
 ];
 
+// empty state obj
+let state = {};
+
 // function to parse and build state.possibilities
 // from rawStatePathRoutes
+function setStatePossibilities(state) {
 
-// function to track state.parts
+    // create state possibilities from possible licenses with adjoining statePaths
+    state.possibilities = [];
+    rawStatePathRoutes.forEach((path, index) => {
 
-// function to update and track state.current
-// this is a full combo of all set state.parts
+        statePath = path.split("&");
+        statepath = statePath;
+        license = statePath[statePath.length - 1].split("=");
+        license = license[1];
+
+        regEx = /\(([^)]+)\)/g;
+        optionals = statePath[0].match(regEx);
+
+        optionals.forEach ((optional) => {
+
+            noOptionalsPath = statePath[0].replace(optional,'');
+
+        });
+
+        fullPath = statePath[0].replace(/[{()}]/g, '') + '/';
+    
+        if (state.possibilities[license] == undefined) {
+            state.possibilities[license] = [];
+        }
+        state.possibilities[license].push(fullPath);
+        state.possibilities[license].push(noOptionalsPath);
+        
+    });
+}
+
+// function to establish state.parts
+function setStateParts(state) {
+    state.parts = [];
+
+    // temp defaults
+    state.parts[0] = 'do-you-know-which-license-you-need/yes/';
+    state.parts[1] = 'which-license-do-you-need/cc-by/';
+    state.parts[8] = 'attribution-details/';
+}
+
+// function to update and track state.parts 
+
+// function to combine current tracked 
+// state.parts into state.current
 
 // function to compare state.possibilities to state.current, 
 // determine if valid license, or error
@@ -43,3 +86,12 @@ let rawStatePathRoutes = [
 // if valid license from state.parts and/or state.current
 
 // function to handle error state
+
+
+// full flow logic 
+setStateParts(state);
+console.log(state.parts);
+
+setStatePossibilities(state);
+ console.log(state.possibilities);
+

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -19,10 +19,9 @@ let rawStatePathRoutes = [
 ];
 
 // function to parse and build state.possibilities
+// from rawStatePathRoutes
 
 // function to track state.parts
-// [T]: should this be a part of state.current
-// as in: state.current.parts ?
 
 // function to update and track state.current
 // this is a full combo of all set state.parts
@@ -33,13 +32,14 @@ let rawStatePathRoutes = [
 // function to set state.props
 // including setting state.props.license (if valid)
 
-// stepper logic here for what parts are displayed,
+// stepper logic here for what parts of form are 
+// displayed/hidden, as state.parts and state.current 
+// are updated
+
+// function to render "license recommendation",
 // if valid license from state.parts and/or state.current
 
-// function to render license recommendation,
-// if valid license from state.parts and/or state.current
-
-// function to render mark your work, from attribution fields
+// function to render "mark your work", from attribution fields
 // if valid license from state.parts and/or state.current
 
 // function to handle error state

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -21,6 +21,9 @@ let rawStatePathRoutes = [
 // empty state obj
 let state = {};
 
+// all found fieldsets
+const fieldsets = document.querySelectorAll('fieldset'); 
+
 // function to parse and build state.possibilities
 // from rawStatePathRoutes
 function setStatePossibilities(state) {
@@ -63,17 +66,98 @@ function setStateParts(state) {
     state.parts[1] = 'which-license-do-you-need/cc-by/';
     state.parts[8] = 'attribution-details/';
 }
+// function to update state.parts
+function updateStateParts(element, index, event, state) {
 
-// function to update and track state.parts 
+    state.parts[index] = element.id + '/' + event.target.value + '/';
+
+    // check if checkbox, with siblings
+    if (event.target.getAttribute('type') == 'checkbox') {        
+        let checkboxElements = element.querySelectorAll('input[type="checkbox"]');
+        let checkboxes = [];
+        checkboxElements.forEach((checkbox, index) => { 
+            if (checkbox.checked) {
+                checkboxes[index] = checkbox.value;
+            }
+        });
+
+
+        let joinedCheckboxes = checkboxes.filter(Boolean).join('+');
+
+        state.parts[index] = element.id + '+' + joinedCheckboxes + '/';;
+    }
+
+    // check if text input
+    if (event.target.getAttribute('type') == 'text') {
+
+        state.parts[index] = element.id + '/';
+
+    }
+
+    console.log("state.parts (after change)");
+    console.log(state.parts);
+}
 
 // function to combine current tracked 
 // state.parts into state.current
+function setStateCurrent(element, index,  state) {
+    state.parts.forEach((element, i) => {
+        if (i > index) {
+            state.parts.splice(i);  
+        }
+    });
+    // [T]: also reset value to nothing each time
+
+    state.current = state.parts.join('') //.slice(0, -1);
+}
+
+// function to set state.props
+// including setting state.props.license (if valid)
+function setStateProps(state) {
+
+    state.props = {};
+    state.props.license = 'unknown';
+
+    // check and match possibilities
+    Object.keys(state.possibilities).forEach((possibility) => {
+        if(state.possibilities[possibility].includes(state.current)) {
+            state.props.license = possibility;
+            console.log('matched');
+        }
+    });
+
+}
+
+// function to watch for fieldset changes 
+function watchFieldsets(fieldsets, state) {
+    fieldsets.forEach((element, index) => {
+
+        // [T]: set defaults here first in state.parts dynamically
+
+        element.addEventListener("change", (event) => {
+
+            console.log("something changed!");
+            updateStateParts(element, index, event, state);
+
+            setStateCurrent(element, index, state);
+            console.log("state.current (after change)");
+            console.log(state.current);
+
+            setStateProps(state);
+            console.log("state.props (after change)");
+            console.log(state.props);
+  
+        });
+
+    });
+}
+
+
 
 // function to compare state.possibilities to state.current, 
 // determine if valid license, or error
 
-// function to set state.props
-// including setting state.props.license (if valid)
+
 
 // stepper logic here for what parts of form are 
 // displayed/hidden, as state.parts and state.current 
@@ -90,10 +174,11 @@ function setStateParts(state) {
 
 // full flow logic 
 setStateParts(state);
-console.log('state.parts (at default)');
+console.log("state.parts (at default)");
 console.log(state.parts);
 
 setStatePossibilities(state);
-console.log('state.possibilities');
+console.log("state.possibilities");
 console.log(state.possibilities);
 
+watchFieldsets(fieldsets, state);

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -24,6 +24,20 @@ let state = {};
 // all found fieldsets
 const fieldsets = document.querySelectorAll('fieldset'); 
 
+// empty defaults obj
+let applyDefaults = {};
+
+// set elemnts which need defaults
+// on initial page load
+applyDefaults.elements = [
+    '#require-attribution',
+    '#allow-commercial-use',
+    '#allow-derivatives',
+    '#share-alike',
+    '#waive-your-copyright',
+    '#confirmation'
+];
+
 // function to parse and build state.possibilities
 // from rawStatePathRoutes
 function setStatePossibilities(state) {
@@ -129,6 +143,100 @@ function setStateProps(state) {
 
 }
 
+// function to render "license recommendation",
+// if valid license from state.parts and/or state.current
+function renderLicenseRec(state) {
+    document.querySelector('#license-recommendation header h3').textContent = state.props.license;
+}
+
+// function to set default UX states on Steps
+// set default visibly disabled pathways
+
+function setDefaults(applyDefaults) {
+
+    applyDefaults.elements.forEach((element) => {
+        document.querySelector(element).classList.toggle('disable');
+    });
+
+    if (state.parts[0] == 'do-you-know-which-license-you-need/yes/' ) {
+        applyDefaults.elements.forEach((element) => {
+            document.querySelector(element).classList.add('disable');
+        });
+    }
+}
+
+// stepper logic here for what parts of form are 
+// displayed/hidden, as state.parts and state.current 
+// are updated
+function renderSteps(applyDefaults, state) {
+
+    // check if visitor needs help, start help pathways
+    if (state.current == 'do-you-know-which-license-you-need/no/' ) {
+
+        applyDefaults.elements.forEach((element) => {
+            document.querySelector(element).classList.remove('disable');
+        });
+        document.querySelector('#which-license-do-you-need').classList.toggle('disable');
+        document.querySelector('#waive-your-copyright').classList.add('disable');
+        
+        console.log("pass one");
+    
+    }
+
+    // if visitor doesn't need help
+    if (state.current == 'do-you-know-which-license-you-need/yes/' ) {
+
+        applyDefaults.elements.forEach((element) => {
+            document.querySelector(element).classList.add('disable');
+        });
+        document.querySelector('#which-license-do-you-need').classList.toggle('disable');
+        document.querySelector('#waive-your-copyright').classList.add('disable');
+
+    }
+
+    // check if cc0
+    if (state.parts[2] == 'require-attribution/no/' || state.parts[1] == 'which-license-do-you-need/cc-0/' ) {
+
+        applyDefaults.elements.forEach((element) => {
+            document.querySelector(element).classList.add('disable');
+        });
+
+        //if (state.parts[0] == 'do-you-know-which-license-you-need/no/') {
+            //document.querySelector('#require-attribution').classList.remove('disable');
+        //}
+        document.querySelector('#waive-your-copyright').classList.remove('disable');
+    
+    } else {
+        document.querySelector('#waive-your-copyright').classList.add('disable');
+    }
+    if (state.parts[2] == 'require-attribution/no/') {
+        document.querySelector('#require-attribution').classList.remove('disable');
+        //document.querySelector('#confirmation').classList.remove('disable');
+    }
+
+    // walk away from cc-0, reset attribution choice point
+    if (state.parts[2] == 'require-attribution/yes/') {
+        applyDefaults.elements.forEach((element) => {
+            document.querySelector(element).classList.remove('disable');
+        });
+        document.querySelector('#require-attribution').classList.remove('disable');
+        document.querySelector('#waive-your-copyright').classList.add('disable');
+
+        //document.querySelector('#confirmation').classList.remove('disable');
+    }
+
+    // tie SA to ND choice
+    if (state.parts[4] == 'allow-derivatives/no/') {
+        document.querySelector('#share-alike').classList.add('disable');
+    }
+    
+}
+
+// function to render "mark your work", from attribution fields
+// if valid license from state.parts and/or state.current
+
+// function to handle error state
+
 // function to watch for fieldset changes 
 function watchFieldsets(fieldsets, state) {
     fieldsets.forEach((element, index) => {
@@ -148,27 +256,13 @@ function watchFieldsets(fieldsets, state) {
             console.log("state.props (after change)");
             console.log(state.props);
 
+            renderSteps(applyDefaults, state);
+
             renderLicenseRec(state);
         });
 
     });
 }
-
-// stepper logic here for what parts of form are 
-// displayed/hidden, as state.parts and state.current 
-// are updated
-
-// function to render "license recommendation",
-// if valid license from state.parts and/or state.current
-function renderLicenseRec(state) {
-    document.querySelector('#license-recommendation header h3').textContent = state.props.license;
-}
-
-// function to render "mark your work", from attribution fields
-// if valid license from state.parts and/or state.current
-
-// function to handle error state
-
 
 // full flow logic 
 setStateParts(state);
@@ -178,5 +272,8 @@ console.log(state.parts);
 setStatePossibilities(state);
 console.log("state.possibilities");
 console.log(state.possibilities);
+
+setDefaults(applyDefaults);
+console.log("initial defaults applied");
 
 watchFieldsets(fieldsets, state);

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -90,8 +90,10 @@ function setStateParts(state) {
 
 // full flow logic 
 setStateParts(state);
+console.log('state.parts (at default)');
 console.log(state.parts);
 
 setStatePossibilities(state);
- console.log(state.possibilities);
+console.log('state.possibilities');
+console.log(state.possibilities);
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -1,1 +1,22 @@
+
+// all possible State Path Routes
+let rawStatePathRoutes = [
+    'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-0/waive-your-copyright+waive+read/(attribution-details)&license=cc-0',
+    'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by/(attribution-details)&license=cc-by',
+    'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by-sa/(attribution-details)&license=cc-by-sa',
+    'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by-nd/(attribution-details)&license=cc-by-nd',
+    'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by-nc/(attribution-details)&license=cc-by-nc',
+    'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by-nc-sa/(attribution-details)&license=cc-by-nc-sa',
+    'do-you-know-which-license-you-need/yes/which-license-do-you-need/cc-by-nc-nd/(attribution-details)&license=cc-by-nc-nd',
+    
+    'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/yes/allow-derivatives/yes/share-alike/no/confirmation+ownership+read+revocation/(attribution-details)&license=cc-by',
+    'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/yes/allow-derivatives/yes/share-alike/yes/confirmation+ownership+read+revocation/(attribution-details)&license=cc-by-sa',
+    'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/yes/allow-derivatives/no/confirmation+ownership+read+revocation/(attribution-details)&license=cc-by-nd',
+    'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/no/allow-derivatives/yes/share-alike/no/confirmation+ownership+read+revocation/(attribution-details)&license=cc-by-nc',
+    'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/no/allow-derivatives/yes/share-alike/yes/confirmation+ownership+read+revocation/(attribution-details)&license=cc-by-nc-sa',
+    'do-you-know-which-license-you-need/no/require-attribution/yes/allow-commercial-use/no/allow-derivatives/no/confirmation+ownership+read+revocation/(attribution-details)&license=cc-by-nc-nd',
+    'do-you-know-which-license-you-need/no/require-attribution/no/waive-your-copyright+waive+read/(attribution-details)&license=cc-0'
+];
+
+
 // stepper logic here

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -154,8 +154,6 @@ function watchFieldsets(fieldsets, state) {
     });
 }
 
-
-
 // stepper logic here for what parts of form are 
 // displayed/hidden, as state.parts and state.current 
 // are updated

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -1,0 +1,1 @@
+// stepper logic here

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -113,6 +113,7 @@ function setStateCurrent(element, index,  state) {
 
 // function to set state.props
 // including setting state.props.license (if valid)
+// or error
 function setStateProps(state) {
 
     state.props = {};
@@ -146,16 +147,12 @@ function watchFieldsets(fieldsets, state) {
             setStateProps(state);
             console.log("state.props (after change)");
             console.log(state.props);
-  
+
+            renderLicenseRec(state);
         });
 
     });
 }
-
-
-
-// function to compare state.possibilities to state.current, 
-// determine if valid license, or error
 
 
 
@@ -165,6 +162,9 @@ function watchFieldsets(fieldsets, state) {
 
 // function to render "license recommendation",
 // if valid license from state.parts and/or state.current
+function renderLicenseRec(state) {
+    document.querySelector('#license-recommendation header h3').textContent = state.props.license;
+}
 
 // function to render "mark your work", from attribution fields
 // if valid license from state.parts and/or state.current

--- a/src/style.css
+++ b/src/style.css
@@ -74,6 +74,10 @@ dd {
     margin-left: .2em;
 }
 
+ol li:has(.disable) {
+    display: none;
+}
+
 
 .license header {
     display: flex;


### PR DESCRIPTION
## Description
* sets baseline objects, arrays, etc.
*  confines various logic parts to functions
* defines possible state paths through the stepper (of which there are 14 valid path routes)
* tracks the parts of the path on change (updates `state.parts`)
* updates the full `state.current` on change
* compares the `state.current` to `state.possibilities` to determine license rec or error
* roughly renders out the recommended license within the "license recommendation" area
* includes working comments and some `console.log` statements for testing and debugging purposes


## Technical details
* ties stepper choice behavior to a dynamic state path that amends at each `fieldset` change
* when a fieldset is changed, the current state is amended to reflect the updated `state.parts`, and then combined into the full updated `state.current`
* `state.current` is compared to `state.possibilities`; if there is a match then a license rec can be made
* if a rec matches, store that within `state.props.license` for use later
* if a license rec can be made then the license recommendation is rendered with the appropriate license (for now it just replaces the placeholder title with a hyphenated one for testing).
* the stepper begins with some fieldsets hidden, and based upon the resulting state from user choice additional fields are displayed or hidden to reflect the correct path flow.
* some bugs remain in the logic, but that'll be worked out in the next batch of PRs (it still needs proper error handling as well), as well as resetting values if someone moves backwards in the steps.

Next up is building out a full render of the license in the "rec area" via a templated Web Component in a simplistic fashion (I'll probably just do one template per license and then refactor in future PRs to be more dynamic), and setting the stage for some error handling for when license is "unknown". Attached to or following that I'll work out the holes in the stepper rendering to smooth out any bugs.

## Screenshots

### Default load with cc-by
![default-cc-by](https://github.com/user-attachments/assets/f82858f1-1738-4380-955d-835e2d9113fe)

### State change upon selection of requisite fields for cc-0
![defalult-cc0](https://github.com/user-attachments/assets/b7669ff2-3c21-4223-a4e9-c2fff68c1c5d)



## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
