### PR TITLE
Implement and Style 404 Error Page with Vue Router Integration #532

### DIFF
--- a/src/components/ErrorPage.vue
+++ b/src/components/ErrorPage.vue
@@ -1,0 +1,68 @@
+<template>
+    <section class="page_404">
+      <div class="container">
+        <div class="row">
+          <div class="col-sm-12">
+            <div class="col-sm-10 col-sm-offset-1 text-center">
+              <div class="four_zero_four_bg">
+                <h1 class="text-center">404</h1>
+              </div>
+  
+              <div class="contant_box_404">
+                <h3 class="h2">
+                  Look like you're lost
+                </h3>
+  
+                <p>The page you are looking for is not available!</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </template>
+  
+  <script>
+  export default {
+    name: 'ErrorPage',
+  };
+  </script>
+  
+  <style scoped>
+  .page_404 {
+    padding: 40px 0;
+    background: #fff;
+    font-family: 'Arvo', serif;
+  }
+  
+  .page_404 img {
+    width: 100%;
+  }
+  
+  .four_zero_four_bg {
+    background-image: url(https://cdn.dribbble.com/users/285475/screenshots/2083086/dribbble_1.gif);
+    height: 400px;
+    background-position: center;
+  }
+  
+  .four_zero_four_bg h1 {
+    font-size: 80px;
+  }
+  
+  .four_zero_four_bg h3 {
+    font-size: 80px;
+  }
+  
+  .link_404 {
+    color: #fff !important;
+    padding: 10px 20px;
+    background: #39ac31;
+    margin: 20px 0;
+    display: inline-block;
+  }
+  
+  .contant_box_404 {
+    margin-top: -50px;
+  }
+  </style>
+  

--- a/src/components/ErrorPage.vue
+++ b/src/components/ErrorPage.vue
@@ -9,7 +9,7 @@
               </div>
   
               <div class="contant_box_404">
-                <h3 class="h2">
+                <h2 class="h2">
                   Look like you're lost
                 </h3>
   

--- a/src/main.js
+++ b/src/main.js
@@ -7,10 +7,13 @@ import VueVocabulary from '@creativecommons/vocabulary-components';
 // Analytics
 import * as Sentry from '@sentry/vue';
 
+// Router setup
+import router from './router'; // Import the router configuration
+
 Vue.config.productionTip = false;
+
 Vue.use(VueVocabulary);
 Vue.use(VueScrollTo);
-
 
 Sentry.init({
   dsn:
@@ -20,12 +23,11 @@ Sentry.init({
   logErrors: process.env.NODE_ENV !== 'production', // Only log errors in dev env
 });
 
-
-if(process.env.VUE_APP_CC_OUTPUT!=='embedded') {
+if (process.env.VUE_APP_CC_OUTPUT !== 'embedded') {
   new Vue({
     render: h => h(App),
+    router, // Add the router to the Vue instance
   }).$mount('#app');
 }
 
 export default App;
-

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,17 @@
+import Vue from 'vue';
+import Router from 'vue-router';
+import ErrorPage from '../components/ErrorPage.vue';
+
+Vue.use(Router);
+
+const router = new Router({
+  routes: [
+    {
+      path: '*', // Wildcard route for any unmatched routes
+      name: 'error',
+      component: ErrorPage // Show the ErrorPage component for 404
+    }
+  ]
+});
+
+export default router;


### PR DESCRIPTION
## Fixes

- Related to #[[532](https://github.com/creativecommons/chooser/issues/532)] by @[[TimidRobot](https://github.com/TimidRobot)]

## Description
-Ensures error pages do not break the flow of the user by preventing navigation disruption as well as ensuring the application's consistency.
-It designs error pages to be as light as possible, thereby optimizing performance and reducing resource usage for faster load times.
-It develops a dedicated ErrorPage.vue component with a clean and minimal aesthetic, styled and themed to fit into the overall design without being too heavy.
-Proper routing is set up through Vue Router to correctly catch 404s, meaning implementation does not use Legacy (Vue) Vocabulary components.

## Technical details
The ErrorPage.vue component was built to show a styled 404 error page using semantic HTML and scoped CSS for a minimal and responsive design. The Vue Router was set up in index.js to forward all unmatched routes (*) to this component so that any invalid URLs were handled seamlessly. The lightweight layout of the error page keeps design consistency and loads fast, with a temporary external background image that could be replaced with a local asset later for more reliability.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

- Verified that the error page appears when accessing non-existent routes.
- Confirmed that the page is styled properly and responsive across different screen sizes.
- Checked that the page is lightweight and does not negatively impact the app’s performance.


## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details> 