### PR TITLE
add baseline `templates` for the various licenses, to load dynamically in "rec area" when a matching `license` is found from `state.current`

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -477,28 +477,28 @@
 
 <template id="cc-0" class="license">
     <header>
-        <h3>CC-0 1.0</h3>
+        <h3>CC0 1.0</h3>
         <span class="license-icons">
             <svg>
                 <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
             </svg>
             <svg>
-                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-0"></use>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-zero"></use>
             </svg>
         </span>
-        <h4>Creative Commons Zero 1.0</h4>
+        <h4>CC0 1.0 Universal</h4>
     </header>
 
     <div class="description">
-        <!-- <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p> -->
+        <p>By marking the work with a CC0 public domain dedication, the creator is giving up their copyright and allowing reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p>
     </div>
 
     <dl class="conditions-definitions">
-        <!-- <dt class="icon-attach cc-by">BY</dt> -->
-        <!-- <dd>Credit must be given to you, the creator.</dd> -->
+        <dt class="icon-attach cc-zero">CC0</dt>
+        <dd>This work has been marked as dedicated to the public domain.</dd>
     </dl>
 
-    <!-- <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a> -->
+    <a href="https://creativecommons.org/publicdomain/zero/1.0/?ref=chooser-v2">See the License Deed</a>
 </template>
 
 <template id="cc-by" class="license">
@@ -529,7 +529,7 @@
 
 <template id="cc-by-sa" class="license">
     <header>
-        <h3>CC-BY-SA 4.0</h3>
+        <h3>CC BY-SA 4.0</h3>
         <span class="license-icons">
             <svg>
                 <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
@@ -541,24 +541,27 @@
                 <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-sa"></use>
             </svg>
         </span>
-        <h4>Creative Commons Attribution Sharealike 4.0 International</h4>
+        <h4>Creative Commons Attribution-ShareAlike 4.0 International</h4>
     </header>
 
     <div class="description">
-        <!-- <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p> -->
+        <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes. If others remix, adapt, or build upon the material, they must license the modified material under identical terms.</p>
     </div>
 
     <dl class="conditions-definitions">
-        <!-- <dt class="icon-attach cc-by">BY</dt> -->
-        <!-- <dd>Credit must be given to you, the creator.</dd> -->
+        <dt class="icon-attach cc-by">BY</dt>
+        <dd>Credit must be given to you, the creator.</dd>
+
+        <dt class="icon-attach cc-sa">SA</dt>
+        <dd>Adaptations must be shared under the same terms.</dd>
     </dl>
 
-    <!-- <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a> -->
+    <a href="https://creativecommons.org/licenses/by-sa/4.0/?ref=chooser-v2">See the License Deed</a>
 </template>
 
 <template id="cc-by-nd" class="license">
     <header>
-        <h3>CC-BY-ND 4.0</h3>
+        <h3>CC BY-ND 4.0</h3>
         <span class="license-icons">
             <svg>
                 <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
@@ -570,24 +573,27 @@
                 <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-nd"></use>
             </svg>
         </span>
-        <h4>Creative Commons Attribution No Derivatives 4.0 International</h4>
+        <h4>Creative Commons Attribution-NoDerivatives 4.0 International</h4>
     </header>
 
     <div class="description">
-        <!-- <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p> -->
+        <p>This license requires that reusers give credit to the creator. It allows reusers to copy and distribute the material in any medium or format in unadapted form only, even for commercial purposes.</p>
     </div>
 
     <dl class="conditions-definitions">
-        <!-- <dt class="icon-attach cc-by">BY</dt> -->
-        <!-- <dd>Credit must be given to you, the creator.</dd> -->
+        <dt class="icon-attach cc-by">BY</dt>
+        <dd>Credit must be given to you, the creator.</dd>
+
+        <dt class="icon-attach cc-nd">ND</dt>
+        <dd>No derivatives or adaptations of your work are permitted.</dd>
     </dl>
 
-    <!-- <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a> -->
+    <a href="https://creativecommons.org/licenses/by-nd/4.0/?ref=chooser-v2">See the License Deed</a>
 </template>
 
 <template id="cc-by-nc" class="license">
     <header>
-        <h3>CC-BY-NC 4.0</h3>
+        <h3>CC BY-NC 4.0</h3>
         <span class="license-icons">
             <svg>
                 <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
@@ -599,24 +605,32 @@
                 <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-nc"></use>
             </svg>
         </span>
-        <h4>Creative Commons Attribution Non-commercial 4.0 International</h4>
+        <h4>Creative Commons Attribution-NonCommercial 4.0 International</h4>
     </header>
 
     <div class="description">
-        <!-- <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p> -->
+        <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, for noncommercial purposes only.</p>
     </div>
 
     <dl class="conditions-definitions">
-        <!-- <dt class="icon-attach cc-by">BY</dt> -->
-        <!-- <dd>Credit must be given to you, the creator.</dd> -->
+        <dt class="icon-attach cc-by">BY</dt>
+        <dd>Credit must be given to you, the creator.</dd>
+
+        <dt class="icon-attach cc-nc">NC</dt>
+        <dd>
+            Only noncommercial use of your work is permitted.
+            <span>Noncommercial means not primarily intended for or directed towards commercial advantage or monetary compensation.</span>
+        </dd>
+
+
     </dl>
 
-    <!-- <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a> -->
+    <a href="https://creativecommons.org/licenses/by-nc/4.0/?ref=chooser-v2">See the License Deed</a>
 </template>
 
 <template id="cc-by-nc-sa" class="license">
     <header>
-        <h3>CC-BY-NC-SA 4.0</h3>
+        <h3>CC BY-NC-SA 4.0</h3>
         <span class="license-icons">
             <svg>
                 <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
@@ -631,24 +645,33 @@
                 <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-sa"></use>
             </svg>
         </span>
-        <h4>Creative Commons Attribution Non-commercial Sharealike 4.0 International</h4>
+        <h4>Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</h4>
     </header>
 
     <div class="description">
-        <!-- <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p> -->
+        <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, for noncommercial purposes only. If others modify or adapt the material, they must license the modified material under identical terms.</p>
     </div>
 
     <dl class="conditions-definitions">
-        <!-- <dt class="icon-attach cc-by">BY</dt> -->
-        <!-- <dd>Credit must be given to you, the creator.</dd> -->
+        <dt class="icon-attach cc-by">BY</dt>
+        <dd>Credit must be given to you, the creator.</dd>
+
+        <dt class="icon-attach cc-nc">NC</dt>
+        <dd>
+            Only noncommercial use of your work is permitted.
+            <span>Noncommercial means not primarily intended for or directed towards commercial advantage or monetary compensation.</span>
+        </dd>
+
+        <dt class="icon-attach cc-sa">SA</dt>
+        <dd>Adaptations must be shared under the same terms.</dd>
     </dl>
 
-    <!-- <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a> -->
+    <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/?ref=chooser-v2">See the License Deed</a>
 </template>
 
 <template id="cc-by-nc-nd" class="license">
     <header>
-        <h3>CC-BY-NC-ND 4.0</h3>
+        <h3>CC BY-NC-ND 4.0</h3>
         <span class="license-icons">
             <svg>
                 <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
@@ -663,19 +686,28 @@
                 <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-nd"></use>
             </svg>
         </span>
-        <h4>Creative Commons Attribution Non-commercial No Derivatives 4.0 International</h4>
+        <h4>Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International</h4>
     </header>
 
     <div class="description">
-        <!-- <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p> -->
+        <p>This license requires that reusers give credit to the creator. It allows reusers to copy and distribute the material in any medium or format in unadapted form and for noncommercial purposes only.</p>
     </div>
 
     <dl class="conditions-definitions">
-        <!-- <dt class="icon-attach cc-by">BY</dt> -->
-        <!-- <dd>Credit must be given to you, the creator.</dd> -->
+        <dt class="icon-attach cc-by">BY</dt>
+        <dd>Credit must be given to you, the creator.</dd>
+
+        <dt class="icon-attach cc-nc">NC</dt>
+        <dd>
+            Only noncommercial use of your work is permitted.
+            <span>Noncommercial means not primarily intended for or directed towards commercial advantage or monetary compensation.</span>
+        </dd>
+
+        <dt class="icon-attach cc-nd">ND</dt>
+        <dd>No derivatives or adaptations of your work are permitted.</dd>
     </dl>
 
-    <!-- <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a> -->
+    <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/?ref=chooser-v2">See the License Deed</a>
 </template>
 
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -313,7 +313,7 @@
 
             <article class="license">
 
-                <header>
+                <!-- <header>
                     <h3>CC-BY 4.0</h3>
                     <span class="license-icons">
                         <svg>
@@ -335,7 +335,7 @@
                     <dd>Credit must be given to you, the creator.</dd>
                 </dl>
 
-            <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a>
+                <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a> -->
 
             </article>
         </div>
@@ -475,8 +475,207 @@
 <script src="scripts.js"></script>
 
 
-<template id="license">
-    <!-- placeholder for swapping out content later with JS -->
+<template id="cc-0" class="license">
+    <header>
+        <h3>CC-0 1.0</h3>
+        <span class="license-icons">
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            </svg>
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-0"></use>
+            </svg>
+        </span>
+        <h4>Creative Commons Zero 1.0</h4>
+    </header>
+
+    <div class="description">
+        <!-- <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p> -->
+    </div>
+
+    <dl class="conditions-definitions">
+        <!-- <dt class="icon-attach cc-by">BY</dt> -->
+        <!-- <dd>Credit must be given to you, the creator.</dd> -->
+    </dl>
+
+    <!-- <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a> -->
+</template>
+
+<template id="cc-by" class="license">
+    <header>
+        <h3>CC-BY 4.0</h3>
+        <span class="license-icons">
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            </svg>
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            </svg>
+        </span>
+        <h4>Creative Commons Attribution 4.0 International</h4>
+    </header>
+
+    <div class="description">
+        <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p>
+    </div>
+
+    <dl class="conditions-definitions">
+        <dt class="icon-attach cc-by">BY</dt>
+        <dd>Credit must be given to you, the creator.</dd>
+    </dl>
+
+    <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a>
+</template>
+
+<template id="cc-by-sa" class="license">
+    <header>
+        <h3>CC-BY-SA 4.0</h3>
+        <span class="license-icons">
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            </svg>
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            </svg>
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-sa"></use>
+            </svg>
+        </span>
+        <h4>Creative Commons Attribution Sharealike 4.0 International</h4>
+    </header>
+
+    <div class="description">
+        <!-- <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p> -->
+    </div>
+
+    <dl class="conditions-definitions">
+        <!-- <dt class="icon-attach cc-by">BY</dt> -->
+        <!-- <dd>Credit must be given to you, the creator.</dd> -->
+    </dl>
+
+    <!-- <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a> -->
+</template>
+
+<template id="cc-by-nd" class="license">
+    <header>
+        <h3>CC-BY-ND 4.0</h3>
+        <span class="license-icons">
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            </svg>
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            </svg>
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-nd"></use>
+            </svg>
+        </span>
+        <h4>Creative Commons Attribution No Derivatives 4.0 International</h4>
+    </header>
+
+    <div class="description">
+        <!-- <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p> -->
+    </div>
+
+    <dl class="conditions-definitions">
+        <!-- <dt class="icon-attach cc-by">BY</dt> -->
+        <!-- <dd>Credit must be given to you, the creator.</dd> -->
+    </dl>
+
+    <!-- <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a> -->
+</template>
+
+<template id="cc-by-nc" class="license">
+    <header>
+        <h3>CC-BY-NC 4.0</h3>
+        <span class="license-icons">
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            </svg>
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            </svg>
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-nc"></use>
+            </svg>
+        </span>
+        <h4>Creative Commons Attribution Non-commercial 4.0 International</h4>
+    </header>
+
+    <div class="description">
+        <!-- <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p> -->
+    </div>
+
+    <dl class="conditions-definitions">
+        <!-- <dt class="icon-attach cc-by">BY</dt> -->
+        <!-- <dd>Credit must be given to you, the creator.</dd> -->
+    </dl>
+
+    <!-- <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a> -->
+</template>
+
+<template id="cc-by-nc-sa" class="license">
+    <header>
+        <h3>CC-BY-NC-SA 4.0</h3>
+        <span class="license-icons">
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            </svg>
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            </svg>
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-nc"></use>
+            </svg>
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-sa"></use>
+            </svg>
+        </span>
+        <h4>Creative Commons Attribution Non-commercial Sharealike 4.0 International</h4>
+    </header>
+
+    <div class="description">
+        <!-- <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p> -->
+    </div>
+
+    <dl class="conditions-definitions">
+        <!-- <dt class="icon-attach cc-by">BY</dt> -->
+        <!-- <dd>Credit must be given to you, the creator.</dd> -->
+    </dl>
+
+    <!-- <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a> -->
+</template>
+
+<template id="cc-by-nc-nd" class="license">
+    <header>
+        <h3>CC-BY-NC-ND 4.0</h3>
+        <span class="license-icons">
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use>
+            </svg>
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-by"></use>
+            </svg>
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-nc"></use>
+            </svg>
+            <svg>
+                <use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-nd"></use>
+            </svg>
+        </span>
+        <h4>Creative Commons Attribution Non-commercial No Derivatives 4.0 International</h4>
+    </header>
+
+    <div class="description">
+        <!-- <p>This license requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.</p> -->
+    </div>
+
+    <dl class="conditions-definitions">
+        <!-- <dt class="icon-attach cc-by">BY</dt> -->
+        <!-- <dd>Credit must be given to you, the creator.</dd> -->
+    </dl>
+
+    <!-- <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v2">See the License Deed</a> -->
 </template>
 
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -138,8 +138,9 @@
 
             <label for="license">License</label>
             <select name="license" id="license">
+                <option value="noselect" selected>&mdash;choose a license&mdash;</option>
                 <option value="cc-0">CC0 1.0</option>
-                <option value="cc-by" selected>CC-BY 4.0</option>
+                <option value="cc-by">CC-BY 4.0</option>
                 <option value="cc-by-sa">CC-BY-SA 4.0</option>
                 <option value="cc-by-nd">CC-BY-ND 4.0</option>
                 <option value="cc-by-nc">CC-BY-NC 4.0</option>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -164,19 +164,14 @@ function clearStepsAfter(fieldsets, state) {
                 console.log('clear at:');
                 console.log(index);
 
-                // change to querySelectorAll and then loop through to reset where appropriate
                 let inputs = element.querySelectorAll('input');
                 inputs.forEach((input, i) => {
                     input.checked = false;
                     console.log('uncheck!');
-
                 });
-
             }
         }
-
     });
-
 }
 
 // function to render "license recommendation",

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -152,7 +152,7 @@ function setStateProps(index, state) {
 // contextual resets to universal defaults
 // unchecked for radio/checkbox, noselect for 
 // selection dropdown, etc.
-function clearStepsAfter(fieldsets, state) {
+function clearStepsAfterCursor(fieldsets, state) {
     fieldsets.forEach((element, index) => {
         if (index > state.props.cursor) {
 
@@ -311,7 +311,7 @@ function watchFieldsets(fieldsets, state) {
             // [T]: also reset values beyond current changed fieldset to nothing each time
             //element.checked = false;
             //console.log('reset values beyond current fieldset to nothing');
-            clearStepsAfter(fieldsets, state);
+            clearStepsAfterCursor(fieldsets, state);
 
             renderSteps(applyDefaults, state);
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -149,11 +149,17 @@ function renderLicenseRec(state) {
     // document.querySelector('#license-recommendation header h3').textContent = state.props.license;
 
     if (state.props.license != 'unknown' ) {
+        document.querySelector('#license-recommendation').classList.remove('disable');
+
         let license = state.props.license;
         let template = document.getElementById(license);
         let templateContent = template.content;
         document.querySelector('#license-recommendation .license').textContent = '';
         document.querySelector('#license-recommendation .license').appendChild(templateContent);
+    }
+    else if (state.props.license == 'unknown') {
+        document.querySelector('#license-recommendation').classList.add('disable');
+        document.querySelector('#license-recommendation .license').textContent = '';
     }
 }
 
@@ -171,6 +177,8 @@ function setDefaults(applyDefaults) {
             document.querySelector(element).classList.add('disable');
         });
     }
+
+    document.querySelector('#license-recommendation').classList.add('disable');
 }
 
 // stepper logic here for what parts of form are 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -77,7 +77,7 @@ function setStateParts(state) {
 
     // temp defaults
     state.parts[0] = 'do-you-know-which-license-you-need/yes/';
-    state.parts[1] = 'which-license-do-you-need/cc-by/';
+    //state.parts[1] = 'which-license-do-you-need/cc-by/';
     state.parts[8] = 'attribution-details/';
 }
 // function to update state.parts
@@ -148,6 +148,10 @@ function setStateProps(index, state) {
 
 // function to reset values beyond current fieldset
 // [T] this could potentially do with a refactor
+// check for input type, and them perform 
+// contextual resets to universal defaults
+// unchecked for radio/checkbox, noselect for 
+// selection dropdown, etc.
 function clearStepsAfter(fieldsets, state) {
     fieldsets.forEach((element, index) => {
         if (index > state.props.cursor) {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -146,7 +146,15 @@ function setStateProps(state) {
 // function to render "license recommendation",
 // if valid license from state.parts and/or state.current
 function renderLicenseRec(state) {
-    document.querySelector('#license-recommendation header h3').textContent = state.props.license;
+    // document.querySelector('#license-recommendation header h3').textContent = state.props.license;
+
+    if (state.props.license != 'unknown' ) {
+        let license = state.props.license;
+        let template = document.getElementById(license);
+        let templateContent = template.content;
+        document.querySelector('#license-recommendation .license').textContent = '';
+        document.querySelector('#license-recommendation .license').appendChild(templateContent);
+    }
 }
 
 // function to set default UX states on Steps

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -118,17 +118,16 @@ function setStateCurrent(element, index,  state) {
     state.parts.forEach((element, i) => {
         if (i > index) {
             state.parts.splice(i);  
-        }
+        } 
     });
-    // [T]: also reset value to nothing each time
-
+    
     state.current = state.parts.join('') //.slice(0, -1);
 }
 
 // function to set state.props
 // including setting state.props.license (if valid)
 // or error
-function setStateProps(state) {
+function setStateProps(index, state) {
 
     state.props = {};
     state.props.license = 'unknown';
@@ -139,6 +138,33 @@ function setStateProps(state) {
             state.props.license = possibility;
             console.log('matched');
         }
+    });
+
+    state.props.cursor = index;
+    console.log('cursor at:');
+    console.log(index);
+
+}
+
+// function to reset values beyond current fieldset
+function clearStepsAfter(fieldsets, state) {
+    // get current fieldset.element index onchange,
+    // then use loop through all fieldset.elements > index
+    // use querySelector to set all child inputs to
+    // empty default values
+
+    // might need a prop of "cursor" which marks where
+    // in the steps we are, do this in state.props
+
+    fieldsets.forEach((element, index) => {
+        if (index > state.props.cursor) {
+            console.log('clear at:');
+            console.log(index);
+
+            // change to querySelectorAll and then loop through to reset where appropriate
+            element.querySelector('input').checked = false;
+        }
+
     });
 
 }
@@ -268,9 +294,14 @@ function watchFieldsets(fieldsets, state) {
             console.log("state.current (after change)");
             console.log(state.current);
 
-            setStateProps(state);
+            setStateProps(index, state);
             console.log("state.props (after change)");
             console.log(state.props);
+
+            // [T]: also reset values beyond current changed fieldset to nothing each time
+            //element.checked = false;
+            //console.log('reset values beyond current fieldset to nothing');
+            clearStepsAfter(fieldsets, state);
 
             renderSteps(applyDefaults, state);
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -147,6 +147,7 @@ function setStateProps(index, state) {
 }
 
 // function to reset values beyond current fieldset
+// [T] this could potentially do with a refactor
 function clearStepsAfter(fieldsets, state) {
     fieldsets.forEach((element, index) => {
         if (index > state.props.cursor) {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -148,21 +148,30 @@ function setStateProps(index, state) {
 
 // function to reset values beyond current fieldset
 function clearStepsAfter(fieldsets, state) {
-    // get current fieldset.element index onchange,
-    // then use loop through all fieldset.elements > index
-    // use querySelector to set all child inputs to
-    // empty default values
-
-    // might need a prop of "cursor" which marks where
-    // in the steps we are, do this in state.props
-
     fieldsets.forEach((element, index) => {
         if (index > state.props.cursor) {
-            console.log('clear at:');
-            console.log(index);
 
-            // change to querySelectorAll and then loop through to reset where appropriate
-            element.querySelector('input').checked = false;
+            if (index == 1) {
+                element.querySelector("#license").value = "noselect";
+            }
+
+            // if (index = 8) {
+
+            // }
+
+            if (index != 1 | index != 8) {
+                console.log('clear at:');
+                console.log(index);
+
+                // change to querySelectorAll and then loop through to reset where appropriate
+                let inputs = element.querySelectorAll('input');
+                inputs.forEach((input, i) => {
+                    input.checked = false;
+                    console.log('uncheck!');
+
+                });
+
+            }
         }
 
     });
@@ -179,9 +188,10 @@ function renderLicenseRec(state) {
 
         let license = state.props.license;
         let template = document.getElementById(license);
-        let templateContent = template.content;
+        let templateContent = template.content.cloneNode(true);
         document.querySelector('#license-recommendation .license').textContent = '';
         document.querySelector('#license-recommendation .license').appendChild(templateContent);
+        console.log('license set to: ' + license);
     }
     else if (state.props.license == 'unknown') {
         document.querySelector('#license-recommendation').classList.add('disable');

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -118,7 +118,7 @@ function setStateCurrent(element, index,  state) {
     state.parts.forEach((element, i) => {
         if (i > index) {
             state.parts.splice(i);  
-        } 
+        }
     });
     
     state.current = state.parts.join('') //.slice(0, -1);

--- a/src/style.css
+++ b/src/style.css
@@ -78,6 +78,10 @@ ol li:has(.disable) {
     display: none;
 }
 
+.disable {
+    display: none;
+}
+
 
 .license header {
     display: flex;
@@ -98,6 +102,12 @@ ol li:has(.disable) {
     width: 1.9em;
     height: 1.9em;
     margin-right: .3em;
+}
+
+.content {
+    display: grid;
+    gap: 2em;
+    grid-template-columns: 1fr 1fr;
 }
 
 

--- a/src/style.css
+++ b/src/style.css
@@ -82,7 +82,6 @@ ol li:has(.disable) {
     display: none;
 }
 
-
 .license header {
     display: flex;
     flex-wrap: wrap;

--- a/src/style.css
+++ b/src/style.css
@@ -99,3 +99,9 @@ ol li:has(.disable) {
     height: 1.9em;
     margin-right: .3em;
 }
+
+
+/* debug styles */
+#mark-your-work, .help {
+    display: none;
+}


### PR DESCRIPTION
## Description
* adds a `<template>` for each `license`
* loads each `license` `<template>` based on `state.props.license` when known
* cycles through various rendering pathways for the UX steps (don't show SA if ND, etc).
* sets a `state.props.cursor` to track current step, and clear any selections left from a previous journey through the steps afterward.
* correctly selects, and renders the appropriate `license` based on valid pathways of selection through the stepper
* sets better defaults on various steps, so explicit decisions have to be made on steps > 0.

## Technical details
* adds additional functions to fully flesh out setting the remaining sub-items of `state`, tracking that and aligning both the `state` with the various UI elements found within the steppers, to keep them in sync along chosen pathways
* there's definitely room for more refactoring how the functions are structured, and a few could do with better generalizations, but it works and I'm moving focus elsewhere until we get to later phases.
* there's also room for the various use of `template` to be generalized more, and sub-divided into sub-templates; and an argument for full conversion to Web Components, but at this stage I don't see the benefit yet at that level of abstraction, and I'm not sure that's necessary in the final refactor either.

Next up, is rendering out the "mark you work" section, pulling relevant input data from the "attribution details" text inputs. I'll also utilize `<template>` here, and keep the output rendering to a minimum (likely only doing plain text formatting for now. Later formatting can be built out in later PRs.

## Screenshots
![two-col-rec-cc0](https://github.com/user-attachments/assets/0fd58f42-957c-4839-bb75-30969ee4c8ff)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
