### PR TITLE
render "mark you work" section, add logic and `state` to support

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -363,7 +363,7 @@
             <p>Copy the text below and paste it on the title and/or copyright page of your print work or presentation, or in the credits of your media.</p>
 
             <h4>Plain Text</h4>
-            <p class="mark-holder">[contextually formatted mark here]</p>
+            <p class="plain-text mark">[contextually formatted mark here]</p>
 
             <footer>
                 <p>[toggle: (license abbreviation) | (full license name)]</p>
@@ -709,6 +709,10 @@
     </dl>
 
     <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/?ref=chooser-v2">See the License Deed</a>
+</template>
+
+<template id="plain-text" class="mark">
+    <p></p>
 </template>
 
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -347,7 +347,7 @@
                 <p>Choose the kind of work to get appropriate license code or public domain marking.</p>
             </header>
 
-            <h3>Website</h3>
+            <!-- <h3>Website</h3>
             <p>If you are licensing or marking one work, paste the code next to it. If you are licensing or marking the whole page or blog, you can paste the code at the bottom of the page.</p>
 
             <h4>Rich Text</h4>
@@ -357,13 +357,13 @@
             <p>[contextually formatted mark here]</p>
 
             <h4>XMP</h4>
-            <p>[contextually formatted mark here]</p>
+            <p>[contextually formatted mark here]</p> -->
 
             <h3>Print Work or Media</h3>
             <p>Copy the text below and paste it on the title and/or copyright page of your print work or presentation, or in the credits of your media.</p>
 
             <h4>Plain Text</h4>
-            <p>[contextually formatted mark here]</p>
+            <p class="mark-holder">[contextually formatted mark here]</p>
 
             <footer>
                 <p>[toggle: (license abbreviation) | (full license name)]</p>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -145,12 +145,17 @@ function setStateProps(index, state) {
     console.log(index);
 
     state.props.attribution = [];
+    setStatePropsAttribution(state);
+}
+
+// isolated function to just set the attribution 
+// subset of state.props (for use other places)
+function setStatePropsAttribution(state) {
     state.props.attribution.title = document.querySelector('#attribution-details #title').value;
     state.props.attribution.creator = document.querySelector('#attribution-details #creator').value;
     state.props.attribution.workLink = document.querySelector('#attribution-details #work-link').value;
     state.props.attribution.creatorLink = document.querySelector('#attribution-details #creator-link').value;
     state.props.attribution.workCreationYear = document.querySelector('#attribution-details #work-creation-year').value;
-
 }
 
 // function to reset values beyond current fieldset
@@ -206,6 +211,24 @@ function renderLicenseRec(state) {
     }
 }
 
+// render specifically the mark formats subsections
+function renderMarkingFormats(state) {
+
+
+    if (state.props.license != 'unknown' ) {}
+
+    setStatePropsAttribution(state);
+
+    let title = state.props.attribution.title;
+    let workCreationYear = state.props.attribution.workCreationYear;
+
+    let phrase = '(c) ' + workCreationYear + ' ' + title + ' is licensed under ';
+    
+    document.querySelector('#mark-your-work .plain-text.mark').textContent = phrase + state.props.license;
+}
+
+
+
 // function to render "mark your work",
 // if valid license from state.parts and/or state.current
 // if attribution details input(s) filled out
@@ -216,17 +239,18 @@ function renderMarkYourWork(state) {
         document.querySelector('#mark-your-work').classList.remove('disable');
 
         //state.props.attribution.title
-        let title = state.props.attribution.title;
-        let workCreationYear = state.props.attribution.workCreationYear;
+        // let title = state.props.attribution.title;
+        // let workCreationYear = state.props.attribution.workCreationYear;
 
-        let phrase = '(c) ' + workCreationYear + ' ' + title + ' is licensed under ';
+        // let phrase = '(c) ' + workCreationYear + ' ' + title + ' is licensed under ';
         
-        document.querySelector('#mark-your-work .mark-holder').textContent = phrase + state.props.license;
+        // document.querySelector('#mark-your-work .mark-holder').textContent = phrase + state.props.license;
+        renderMarkingFormats(state);
 
     }
     
     else if (state.props.license == 'unknown') {
-        // set to empty
+        document.querySelector('#mark-your-work').classList.add('disable');
     }
 
 }
@@ -351,6 +375,22 @@ function watchFieldsets(fieldsets, state) {
             renderLicenseRec(state);
 
             renderMarkYourWork(state);
+
+        });
+
+    });
+}
+
+function watchAttributionDetails(fieldsets, state) {
+
+    let textFields = fieldsets[8].querySelectorAll('input');
+
+    textFields.forEach((element, index) => {
+
+        element.addEventListener("keyup", (event) => {
+            console.log('typing is happening');
+
+            renderMarkingFormats(state);
         });
 
     });
@@ -368,4 +408,8 @@ console.log(state.possibilities);
 setDefaults(applyDefaults);
 console.log("initial defaults applied");
 
+setStateProps(0, state);
+console.log("initial defaults applied");
+
 watchFieldsets(fieldsets, state);
+watchAttributionDetails(fieldsets, state);

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -140,6 +140,26 @@ function setStateProps(index, state) {
         }
     });
 
+    // set full license human readable name && full license URL
+    if (state.props.license != 'unknown' | state.props.license != 'cc-0' ) {
+
+        formattedLicense = state.props.license.replace(/-/, ' ').toUpperCase();
+        state.props.licenseFull = formattedLicense + ' 4.0';
+
+        shortName = state.props.license.replace(/cc-/, '');
+        state.props.licenseURL = 'https://creativecommons.org/licenses/'+ shortName +'/4.0/'; 
+    }
+
+    if (state.props.license == 'cc-0') {
+
+        state.props.licenseFull = 'CC0 1.0';
+
+        state.props.licenseURL = 'https://creativecommons.org/publicdomain/zero/1.0/';
+    }
+
+
+
+
     state.props.cursor = index;
     console.log('cursor at:');
     console.log(index);
@@ -219,12 +239,21 @@ function renderMarkingFormats(state) {
 
     setStatePropsAttribution(state);
 
-    let title = state.props.attribution.title;
-    let workCreationYear = state.props.attribution.workCreationYear;
+    //let title = state.props.attribution.title;
+    //let workCreationYear = state.props.attribution.workCreationYear;
 
-    let phrase = '(c) ' + workCreationYear + ' ' + title + ' is licensed under ';
+    //let phrase = '(c) ' + workCreationYear + ' ' + title + ' is licensed under ';
+
+    let attribution = state.props.attribution;
+
+    let type = "licensed under";
+    if (state.props.license == 'cc-0') {
+        type = "marked";
+    }
+
+    let mark = attribution.title + ' © ' + attribution.workCreationYear + ' by ' + attribution.creator + ' is ' + type  + ' ' + state.props.licenseFull + '. To view a copy of this license, visit ' + state.props.licenseURL;
     
-    document.querySelector('#mark-your-work .plain-text.mark').textContent = phrase + state.props.license;
+    document.querySelector('#mark-your-work .plain-text.mark').textContent = mark;
 }
 
 
@@ -375,6 +404,8 @@ function watchFieldsets(fieldsets, state) {
             renderLicenseRec(state);
 
             renderMarkYourWork(state);
+
+            console.log(state.props.licenseFull);
 
         });
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -140,11 +140,13 @@ function setStateProps(index, state) {
         }
     });
 
-    // set full license human readable name && full license URL
+    // set licenseFull, licenseShort, licenseURL
     if (state.props.license != 'unknown' | state.props.license != 'cc-0' ) {
 
         formattedLicense = state.props.license.replace(/-/, ' ').toUpperCase();
         state.props.licenseFull = formattedLicense + ' 4.0';
+
+        // set licenseShort
 
         shortName = state.props.license.replace(/cc-/, '');
         state.props.licenseURL = 'https://creativecommons.org/licenses/'+ shortName +'/4.0/'; 
@@ -153,6 +155,8 @@ function setStateProps(index, state) {
     if (state.props.license == 'cc-0') {
 
         state.props.licenseFull = 'CC0 1.0';
+
+        // set licenseShort
 
         state.props.licenseURL = 'https://creativecommons.org/publicdomain/zero/1.0/';
     }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -144,9 +144,9 @@ function setStateProps(index, state) {
     if (state.props.license != 'unknown' | state.props.license != 'cc-0' ) {
 
         formattedLicense = state.props.license.replace(/-/, ' ').toUpperCase();
-        state.props.licenseFull = formattedLicense + ' 4.0';
+        state.props.licenseShort = formattedLicense + ' 4.0';
 
-        // set licenseShort
+        // set licenseFhort
 
         shortName = state.props.license.replace(/cc-/, '');
         state.props.licenseURL = 'https://creativecommons.org/licenses/'+ shortName +'/4.0/'; 
@@ -154,9 +154,9 @@ function setStateProps(index, state) {
 
     if (state.props.license == 'cc-0') {
 
-        state.props.licenseFull = 'CC0 1.0';
+        state.props.licenseShort = 'CC0 1.0';
 
-        // set licenseShort
+        // set licenseFull
 
         state.props.licenseURL = 'https://creativecommons.org/publicdomain/zero/1.0/';
     }
@@ -255,7 +255,7 @@ function renderMarkingFormats(state) {
         type = "marked";
     }
 
-    let mark = attribution.title + ' © ' + attribution.workCreationYear + ' by ' + attribution.creator + ' is ' + type  + ' ' + state.props.licenseFull + '. To view a copy of this license, visit ' + state.props.licenseURL;
+    let mark = attribution.title + ' © ' + attribution.workCreationYear + ' by ' + attribution.creator + ' is ' + type  + ' ' + state.props.licenseShort + '. To view a copy of this license, visit ' + state.props.licenseURL;
     
     document.querySelector('#mark-your-work .plain-text.mark').textContent = mark;
 }
@@ -409,7 +409,7 @@ function watchFieldsets(fieldsets, state) {
 
             renderMarkYourWork(state);
 
-            console.log(state.props.licenseFull);
+            console.log(state.props.licenseShort);
 
         });
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -144,6 +144,13 @@ function setStateProps(index, state) {
     console.log('cursor at:');
     console.log(index);
 
+    state.props.attribution = [];
+    state.props.attribution.title = document.querySelector('#attribution-details #title').value;
+    state.props.attribution.creator = document.querySelector('#attribution-details #creator').value;
+    state.props.attribution.workLink = document.querySelector('#attribution-details #work-link').value;
+    state.props.attribution.creatorLink = document.querySelector('#attribution-details #creator-link').value;
+    state.props.attribution.workCreationYear = document.querySelector('#attribution-details #work-creation-year').value;
+
 }
 
 // function to reset values beyond current fieldset
@@ -199,6 +206,31 @@ function renderLicenseRec(state) {
     }
 }
 
+// function to render "mark your work",
+// if valid license from state.parts and/or state.current
+// if attribution details input(s) filled out
+function renderMarkYourWork(state) {
+    if (state.props.license != 'unknown' ) {
+        // load attribution details template, 
+        // populate from attribution text values
+        document.querySelector('#mark-your-work').classList.remove('disable');
+
+        //state.props.attribution.title
+        let title = state.props.attribution.title;
+        let workCreationYear = state.props.attribution.workCreationYear;
+
+        let phrase = '(c) ' + workCreationYear + ' ' + title + ' is licensed under ';
+        
+        document.querySelector('#mark-your-work .mark-holder').textContent = phrase + state.props.license;
+
+    }
+    
+    else if (state.props.license == 'unknown') {
+        // set to empty
+    }
+
+}
+
 // function to set default UX states on Steps
 // set default visibly disabled pathways
 
@@ -215,6 +247,7 @@ function setDefaults(applyDefaults) {
     }
 
     document.querySelector('#license-recommendation').classList.add('disable');
+    document.querySelector('#mark-your-work').classList.add('disable');
 }
 
 // stepper logic here for what parts of form are 
@@ -316,6 +349,8 @@ function watchFieldsets(fieldsets, state) {
             renderSteps(applyDefaults, state);
 
             renderLicenseRec(state);
+
+            renderMarkYourWork(state);
         });
 
     });

--- a/src/style.css
+++ b/src/style.css
@@ -111,6 +111,6 @@ ol li:has(.disable) {
 
 
 /* debug styles */
-#mark-your-work, .help {
+.help {
     display: none;
 }


### PR DESCRIPTION
## Description
* hides other formats for later work, focuses only on the "plain text" marking format
* adds appropriate modularized functions to render the "mark your work" section if a matching `license` if found
* adds a new watcher to track changes in "attribution details" and update in "plain text" "mark your work" format
*  adds new `state.props.licenseShort` and `state.props.licenseURL` to the state obj for use in formatting or other areas
* adds new `state.props.attribution` to store attribution details for onChange dynamic access
* sets up an empty mark `<template>` for use later with possible inclusion of WebComponent implementation for mark formats
* establishes baseline core structure functionality, so that it can be built out further modularly within this process, and allow enough functionality to now add the styling layer on top.

## Technical details
* the "mark your work" area now displays in the appropriate spot if a matching `license` is found
* a new watcher tracks `keyup` changes on the `inputs` of the "attribution details" area, and dynamically stores those values within the `state` obj
* new functionality then renders the mark formats (at the moment only `plain text`), building a relevant mark string from `state`
* the `plain text` format now dynamically renders not only the initial placeholder values of the "attribution details", but also any changes an end-user makes dynamically, while also matching to the relevant `license/tool` choice made via the `stepper`

Next up is cleaning up a bit of the function structure, settled around more stable and helpful namespacing, and building out the remaining functionality for a fully functional "mark your work" formats area. Once that's settled I'll move to applying the style layer by building out necessary localized changes to append Vocabulary and move closer to reasonable UX comparison to the current `Vue.js` implementation. That should then provide room for future PRs to handle additional formatting implementations (like JSON-LD)

## Screenshots
![chooser-mark-rough](https://github.com/user-attachments/assets/4268f4e2-2915-4100-967f-ff026d779593)

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
