### PR TITLE
improve formats UX (markup and styling), add `details/summary` to mediums and formats

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -351,29 +351,35 @@
             <p>If you are licensing or marking one work, paste the code next to it. If you are licensing or marking the whole page or blog, you can paste the code at the bottom of the page.</p>
 
             <article>
-                <h4>Rich Text</h4>
-                <p class="rich-text mark">[contextually formatted mark here]</p>
+                <h4><button>Rich Text</button></h4>
 
-                <footer>
-                    <div>
-                        <input type="checkbox" id="rich-text-full-name" name="rich-text-full-name" value="rich-text-full-name" />
-                        <label for="rich-text-full-name">full tool name</label>
-                    </div>
-                    <button id="copy-rich-text-mark">Copy</button>
-                </footer>
+                <div class="panel">
+                    <p class="rich-text mark">[contextually formatted mark here]</p>
+
+                    <footer>
+                        <div>
+                            <input type="checkbox" id="rich-text-full-name" name="rich-text-full-name" value="rich-text-full-name" />
+                            <label for="rich-text-full-name">full tool name</label>
+                        </div>
+                        <button id="copy-rich-text-mark">Copy</button>
+                    </footer>
+                </div>
             </article>
 
             <article>
-                <h4>HTML</h4>
-                <p class="html mark">[contextually formatted mark here]</p>
+                <h4><button>HTML</button></h4>
 
-                <footer>
-                    <div>
-                        <input type="checkbox" id="html-full-name" name="html-full-name" value="html-full-name" />
-                        <label for="html-full-name">full tool name</label>
-                    </div>
-                    <button id="copy-html-mark">Copy</button>
-                </footer>
+                <div class="panel">
+                    <p class="html mark">[contextually formatted mark here]</p>
+
+                    <footer>
+                        <div>
+                            <input type="checkbox" id="html-full-name" name="html-full-name" value="html-full-name" />
+                            <label for="html-full-name">full tool name</label>
+                        </div>
+                        <button id="copy-html-mark">Copy</button>
+                    </footer>
+                </div>
             </article>
 
             <!-- <h4>XMP</h4>
@@ -383,17 +389,19 @@
             <p>Copy the text below and paste it on the title and/or copyright page of your print work or presentation, or in the credits of your media.</p>
 
             <article>
-                <h4>Plain Text</h4>
+                <h4><button>Plain Text</button></h4>
 
-                <p class="plain-text mark">[contextually formatted mark here]</p>
+                <div class="panel">
+                    <p class="plain-text mark">[contextually formatted mark here]</p>
 
-                <footer>
-                    <div>
-                        <input type="checkbox" id="plain-text-full-name" name="plain-text-full-name" value="plain-text-full-name" />
-                        <label for="plain-text-full-name">full tool name</label>
-                    </div>
-                    <button id="copy-plain-text-mark">Copy</button>
-                </footer>
+                    <footer>
+                        <div>
+                            <input type="checkbox" id="plain-text-full-name" name="plain-text-full-name" value="plain-text-full-name" />
+                            <label for="plain-text-full-name">full tool name</label>
+                        </div>
+                        <button id="copy-plain-text-mark">Copy</button>
+                    </footer>
+                </div>
             </article>
 
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -347,7 +347,7 @@
                 <p>Choose the kind of work to get appropriate license code or public domain marking.</p>
             </header>
 
-            <!-- <h3>Website</h3>
+            <h3>Website</h3>
             <p>If you are licensing or marking one work, paste the code next to it. If you are licensing or marking the whole page or blog, you can paste the code at the bottom of the page.</p>
 
             <h4>Rich Text</h4>
@@ -356,7 +356,7 @@
             <h4>HTML</h4>
             <p>[contextually formatted mark here]</p>
 
-            <h4>XMP</h4>
+            <!-- <h4>XMP</h4>
             <p>[contextually formatted mark here]</p> -->
 
             <h3>Print Work or Media</h3>

--- a/src/index.html
+++ b/src/index.html
@@ -352,7 +352,7 @@
 
             <article>
                 <h4>Rich Text</h4>
-                <p>[contextually formatted mark here]</p>
+                <p class="rich-text mark">[contextually formatted mark here]</p>
 
                 <footer>
                     <div>
@@ -365,7 +365,7 @@
 
             <article>
                 <h4>HTML</h4>
-                <p>[contextually formatted mark here]</p>
+                <p class="html mark">[contextually formatted mark here]</p>
 
                 <footer>
                     <div>

--- a/src/index.html
+++ b/src/index.html
@@ -220,8 +220,8 @@
             </div>
         
             <div>
-                <input type="radio" id="no-sharing-requirements" name="sharing-requirements" value="no" />
-                <label for="sharing-requirements">No</label>
+                <input type="radio" id="no-sharing-requirements" name="no-sharing-requirements" value="no" />
+                <label for="no-sharing-requirements">No</label>
             </div>
 
         </fieldset>

--- a/src/index.html
+++ b/src/index.html
@@ -350,11 +350,31 @@
             <h3>Website</h3>
             <p>If you are licensing or marking one work, paste the code next to it. If you are licensing or marking the whole page or blog, you can paste the code at the bottom of the page.</p>
 
-            <h4>Rich Text</h4>
-            <p>[contextually formatted mark here]</p>
+            <article>
+                <h4>Rich Text</h4>
+                <p>[contextually formatted mark here]</p>
 
-            <h4>HTML</h4>
-            <p>[contextually formatted mark here]</p>
+                <footer>
+                    <div>
+                        <input type="checkbox" id="rich-text-full-name" name="rich-text-full-name" value="rich-text-full-name" />
+                        <label for="rich-text-full-name">full tool name</label>
+                    </div>
+                    <button id="copy-rich-text-mark">Copy</button>
+                </footer>
+            </article>
+
+            <article>
+                <h4>HTML</h4>
+                <p>[contextually formatted mark here]</p>
+
+                <footer>
+                    <div>
+                        <input type="checkbox" id="html-full-name" name="html-full-name" value="html-full-name" />
+                        <label for="html-full-name">full tool name</label>
+                    </div>
+                    <button id="copy-html-mark">Copy</button>
+                </footer>
+            </article>
 
             <!-- <h4>XMP</h4>
             <p>[contextually formatted mark here]</p> -->
@@ -362,14 +382,19 @@
             <h3>Print Work or Media</h3>
             <p>Copy the text below and paste it on the title and/or copyright page of your print work or presentation, or in the credits of your media.</p>
 
-            <h4>Plain Text</h4>
-            <p class="plain-text mark">[contextually formatted mark here]</p>
+            <article>
+                <h4>Plain Text</h4>
 
-            <footer>
-                <p>[toggle: (license abbreviation) | (full license name)]</p>
-                <button>Copy</button>
-                <button>Download</button>
-            </footer>
+                <p class="plain-text mark">[contextually formatted mark here]</p>
+
+                <footer>
+                    <div>
+                        <input type="checkbox" id="plain-text-full-name" name="plain-text-full-name" value="plain-text-full-name" />
+                        <label for="plain-text-full-name">full tool name</label>
+                    </div>
+                    <button id="copy-plain-text-mark">Copy</button>
+                </footer>
+            </article>
 
         </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -14,7 +14,7 @@
 
 </head>
 
-<body>
+<body class="chooser-page">
 <a class="skip-to-content" href="#main-content-marker">Skip to content</a>
 
 <header>
@@ -327,7 +327,7 @@
 
     <aside>
         <div id="tool-recommendation">
-            <h2>Recommended</h2>
+            <h2>Recommended Choice</h2>
 
             <article class="tool">
 
@@ -364,17 +364,16 @@
                 <p>Choose the kind of work to get appropriate license code or public domain marking.</p>
             </header>
 
-            <section>
+            <details class="medium">
 
-            <h3><button class="expandPanel">Website</button></h3>
+            <summary>Website</summary>
 
-            <div class="panel">
                 <p>If you are licensing or marking one work, paste the code next to it. If you are licensing or marking the whole page or blog, you can paste the code at the bottom of the page.</p>
 
                 <article>
-                    <h4><button class="expandPanel">Rich Text</button></h4>
+                    <details class="format">
+                    <summary>Rich Text</summary>
 
-                    <div class="panel">
                         <p class="rich-text mark">[contextually formatted mark here]</p>
 
                         <footer>
@@ -384,13 +383,13 @@
                             </div>
                             <button id="copy-rich-text-mark">Copy</button>
                         </footer>
-                    </div>
+                    </details>
                 </article>
 
                 <article>
-                    <h4><button class="expandPanel">HTML</button></h4>
+                    <details class="format">
+                    <summary>HTML</summary>
 
-                    <div class="panel">
                         <p class="html mark">[contextually formatted mark here]</p>
 
                         <footer>
@@ -400,26 +399,23 @@
                             </div>
                             <button id="copy-html-mark">Copy</button>
                         </footer>
-                    </div>
+                    </details>
                 </article>
 
                 <!-- <h4>XMP</h4>
                 <p>[contextually formatted mark here]</p> -->
-            </div>
 
-            </section>
+            </details>
             
-            <section>
+            <details class="medium">
+            <summary>Print Work or Media</summary>
 
-            <h3><button class="expandPanel">Print Work or Media</button></h3>
-
-            <div class="panel">
                 <p>Copy the text below and paste it on the title and/or copyright page of your print work or presentation, or in the credits of your media.</p>
 
                 <article>
-                    <h4><button class="expandPanel">Plain Text</button></h4>
+                <details class="format">
+                    <summary>Plain Text</summary>
 
-                    <div class="panel">
                         <p class="plain-text mark">[contextually formatted mark here]</p>
 
                         <footer>
@@ -429,10 +425,9 @@
                             </div>
                             <button id="copy-plain-text-mark">Copy</button>
                         </footer>
-                    </div>
+                </details>
                 </article>
-            </div>
-            </section>
+            </details>
 
         </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -300,6 +300,23 @@
                 <input type="text" id="work-creation-year" name="work-creation-year" value="1999" />
             </div>
 
+            <div id="tool-rec-details">
+
+                <hr />
+
+                <div>
+                    <label for="tool-title">Title of recommended tool (read only)</label>
+                    <input type="text" id="tool-title" name="tool-title" value="recommended tool title" readonly="true" />
+                </div>
+
+                <div>
+                    <label for="tool-url">URL of recommended tool (read only)</label>
+                    <input type="text" id="tool-url" name="tool-url" value="https://creativecommons.org/licenses/by/4.0/" readonly="true" />
+                </div>
+
+            </div>
+   
+
         </fieldset>
         </li>
 

--- a/src/index.html
+++ b/src/index.html
@@ -347,62 +347,75 @@
                 <p>Choose the kind of work to get appropriate license code or public domain marking.</p>
             </header>
 
-            <h3>Website</h3>
-            <p>If you are licensing or marking one work, paste the code next to it. If you are licensing or marking the whole page or blog, you can paste the code at the bottom of the page.</p>
+            <section>
 
-            <article>
-                <h4><button>Rich Text</button></h4>
+            <h3><button class="expandPanel">Website</button></h3>
 
-                <div class="panel">
-                    <p class="rich-text mark">[contextually formatted mark here]</p>
+            <div class="panel">
+                <p>If you are licensing or marking one work, paste the code next to it. If you are licensing or marking the whole page or blog, you can paste the code at the bottom of the page.</p>
 
-                    <footer>
-                        <div>
-                            <input type="checkbox" id="rich-text-full-name" name="rich-text-full-name" value="rich-text-full-name" />
-                            <label for="rich-text-full-name">full tool name</label>
-                        </div>
-                        <button id="copy-rich-text-mark">Copy</button>
-                    </footer>
-                </div>
-            </article>
+                <article>
+                    <h4><button class="expandPanel">Rich Text</button></h4>
 
-            <article>
-                <h4><button>HTML</button></h4>
+                    <div class="panel">
+                        <p class="rich-text mark">[contextually formatted mark here]</p>
 
-                <div class="panel">
-                    <p class="html mark">[contextually formatted mark here]</p>
+                        <footer>
+                            <div>
+                                <input type="checkbox" id="rich-text-full-name" name="rich-text-full-name" value="rich-text-full-name" />
+                                <label for="rich-text-full-name">full tool name</label>
+                            </div>
+                            <button id="copy-rich-text-mark">Copy</button>
+                        </footer>
+                    </div>
+                </article>
 
-                    <footer>
-                        <div>
-                            <input type="checkbox" id="html-full-name" name="html-full-name" value="html-full-name" />
-                            <label for="html-full-name">full tool name</label>
-                        </div>
-                        <button id="copy-html-mark">Copy</button>
-                    </footer>
-                </div>
-            </article>
+                <article>
+                    <h4><button class="expandPanel">HTML</button></h4>
 
-            <!-- <h4>XMP</h4>
-            <p>[contextually formatted mark here]</p> -->
+                    <div class="panel">
+                        <p class="html mark">[contextually formatted mark here]</p>
 
-            <h3>Print Work or Media</h3>
-            <p>Copy the text below and paste it on the title and/or copyright page of your print work or presentation, or in the credits of your media.</p>
+                        <footer>
+                            <div>
+                                <input type="checkbox" id="html-full-name" name="html-full-name" value="html-full-name" />
+                                <label for="html-full-name">full tool name</label>
+                            </div>
+                            <button id="copy-html-mark">Copy</button>
+                        </footer>
+                    </div>
+                </article>
 
-            <article>
-                <h4><button>Plain Text</button></h4>
+                <!-- <h4>XMP</h4>
+                <p>[contextually formatted mark here]</p> -->
+            </div>
 
-                <div class="panel">
-                    <p class="plain-text mark">[contextually formatted mark here]</p>
+            </section>
+            
+            <section>
 
-                    <footer>
-                        <div>
-                            <input type="checkbox" id="plain-text-full-name" name="plain-text-full-name" value="plain-text-full-name" />
-                            <label for="plain-text-full-name">full tool name</label>
-                        </div>
-                        <button id="copy-plain-text-mark">Copy</button>
-                    </footer>
-                </div>
-            </article>
+            <h3><button class="expandPanel">Print Work or Media</button></h3>
+
+            <div class="panel">
+                <p>Copy the text below and paste it on the title and/or copyright page of your print work or presentation, or in the credits of your media.</p>
+
+                <article>
+                    <h4><button class="expandPanel">Plain Text</button></h4>
+
+                    <div class="panel">
+                        <p class="plain-text mark">[contextually formatted mark here]</p>
+
+                        <footer>
+                            <div>
+                                <input type="checkbox" id="plain-text-full-name" name="plain-text-full-name" value="plain-text-full-name" />
+                                <label for="plain-text-full-name">full tool name</label>
+                            </div>
+                            <button id="copy-plain-text-mark">Copy</button>
+                        </footer>
+                    </div>
+                </article>
+            </div>
+            </section>
 
         </div>
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -407,6 +407,7 @@ function setDefaults(applyDefaults) {
 
     document.querySelector('#tool-recommendation').classList.add('disable');
     document.querySelector('#mark-your-work').classList.add('disable');
+    document.querySelector('#tool-rec-details').classList.add('hide');
 }
 
 // stepper logic here for what parts of form are 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -285,11 +285,24 @@ function renderMarkingFormats(state) {
         console.log(templateContent);
     }
 
+    // set contents of plain text mark
+    // TODO: reverse use of <template> since it has limits on tokenization capacity, even if
+    // it allows more dev readability.
     document.querySelector('#mark-your-work .plain-text.mark').appendChild(templateContent);
 
 
     //templateContent.textContent = parseTokens("year", attribution.workCreationYear, templateContent.textContent);
     //document.querySelector('#mark-your-work .plain-text.mark').appendChild(templateContent);
+
+
+    // set contents of rich text mark
+    let richTextMark = attribution.title + ' © ' + attribution.workCreationYear + ' by ' + attribution.creator + ' is ' + typeAsVerb  + ' ' + '<a href="#">' + state.props.toolShort + '</a> <svg><use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use></svg> <svg><use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-by"></use></svg> <svg><use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-sa"></use></svg> ';
+    document.querySelector('#mark-your-work .rich-text.mark').innerHTML = richTextMark;
+
+
+    // set contents of HTML mark
+    let htmlMark = '<textarea readonly="true">' + attribution.title + '</textarea>';
+    document.querySelector('#mark-your-work .html.mark').innerHTML = htmlMark;
 }
 
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -239,7 +239,6 @@ function renderToolRec(state) {
 // render specifically the mark formats subsections
 function renderMarkingFormats(state) {
 
-
     if (state.props.tool != 'unknown' ) {}
 
     setStatePropsAttribution(state);
@@ -261,6 +260,10 @@ function renderMarkingFormats(state) {
     //let mark = attribution.title + ' © ' + attribution.workCreationYear + ' by ' + attribution.creator + ' is ' + type  + ' ' + state.props.toolShort + '. To view a copy of this license, visit ' + state.props.toolURL;
     //document.querySelector('#mark-your-work .plain-text.mark').textContent = mark;
 
+
+    // set contents of plain text mark
+    // TODO: reverse use of <template> since it has limits on tokenization capacity, even if
+    // it allows more dev readability.
     let template = document.getElementById('plain-text');
     let templateContent = template.content.cloneNode(true);
     document.querySelector('#mark-your-work .plain-text.mark').textContent = '';
@@ -286,9 +289,6 @@ function renderMarkingFormats(state) {
         console.log(templateContent);
     }
 
-    // set contents of plain text mark
-    // TODO: reverse use of <template> since it has limits on tokenization capacity, even if
-    // it allows more dev readability.
     document.querySelector('#mark-your-work .plain-text.mark').appendChild(templateContent);
 
 
@@ -330,12 +330,13 @@ function renderMarkingFormats(state) {
             currentTool = '';
     }
 
-    let richTextMark = attribution.title + ' © ' + attribution.workCreationYear + ' by ' + attribution.creator + ' is ' + typeAsVerb  + ' ' + '<a href="#">' + state.props.toolShort + '</a>' + ccIconSet;
+    let richTextMark = attribution.title + ' © ' + attribution.workCreationYear + ' by ' + attribution.creator + ' is ' + typeAsVerb  + ' ' + '<a href="' + state.props.toolURL + '">' + state.props.toolShort + '</a>' + ccIconSet;
     document.querySelector('#mark-your-work .rich-text.mark').innerHTML = richTextMark;
 
 
     // set contents of HTML mark
-    let htmlMark = '<textarea readonly="true">' + attribution.title + '</textarea>';
+    defaultHTML = '<p xmlns:cc="http://creativecommons.org/ns#">This work is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="license noopener noreferrer">CC BY-SA 4.0<img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1" alt=""><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt=""><img src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt=""></a></p>';
+    let htmlMark = '<textarea readonly="true">' + defaultHTML + '</textarea>';
     document.querySelector('#mark-your-work .html.mark').innerHTML = htmlMark;
 }
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -550,3 +550,19 @@ console.log("initial defaults applied");
 
 watchFieldsets(fieldsets, state);
 watchAttributionDetails(fieldsets, state);
+
+
+
+// rough panel expansion test
+let expandButtons = document.querySelectorAll('button.expandPanel');
+
+expandButtons.forEach((element, index) => { 
+    element.addEventListener("click", (event) => {
+
+        parent = event.target.parentNode.parentNode;
+        parent.querySelector('.panel').classList.toggle('expand');
+        console.log('expanded!');
+    
+    });
+});
+

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -172,14 +172,15 @@ function setStateProps(index, state) {
     setStatePropsAttribution(state);
 }
 
+
 // isolated function to just set the attribution 
 // subset of state.props (for use other places)
 function setStatePropsAttribution(state) {
-    state.props.attribution.title = document.querySelector('#attribution-details #title').value;
-    state.props.attribution.creator = document.querySelector('#attribution-details #creator').value;
-    state.props.attribution.workLink = document.querySelector('#attribution-details #work-link').value;
-    state.props.attribution.creatorLink = document.querySelector('#attribution-details #creator-link').value;
-    state.props.attribution.workCreationYear = document.querySelector('#attribution-details #work-creation-year').value;
+    state.props.attribution.title = document.querySelector('#attribution-details #title').value.replace(/(<([^>]+)>)/gi, "");
+    state.props.attribution.creator = document.querySelector('#attribution-details #creator').value.replace(/(<([^>]+)>)/gi, "");
+    state.props.attribution.workLink = document.querySelector('#attribution-details #work-link').value.replace(/(<([^>]+)>)/gi, "");
+    state.props.attribution.creatorLink = document.querySelector('#attribution-details #creator-link').value.replace(/(<([^>]+)>)/gi, "");
+    state.props.attribution.workCreationYear = document.querySelector('#attribution-details #work-creation-year').value.replace(/(<([^>]+)>)/gi, "");
 }
 
 // function to reset values beyond current fieldset
@@ -294,9 +295,42 @@ function renderMarkingFormats(state) {
     //templateContent.textContent = parseTokens("year", attribution.workCreationYear, templateContent.textContent);
     //document.querySelector('#mark-your-work .plain-text.mark').appendChild(templateContent);
 
-
     // set contents of rich text mark
-    let richTextMark = attribution.title + ' © ' + attribution.workCreationYear + ' by ' + attribution.creator + ' is ' + typeAsVerb  + ' ' + '<a href="#">' + state.props.toolShort + '</a> <svg><use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use></svg> <svg><use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-by"></use></svg> <svg><use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-sa"></use></svg> ';
+    let ccSVG = '<svg><use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-logo"></use></svg>';
+    let bySVG = '<svg><use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-by"></use></svg>';
+    let saSVG = '<svg><use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-sa"></use></svg>';
+    let ncSVG = '<svg><use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-nc"></use></svg>';
+    let ndSVG = '<svg><use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-nd"></use></svg>';
+    let zeroSVG = '<svg><use href="vocabulary/svg/cc/icons/cc-icons.svg#cc-zero"></use></svg>';
+
+    const currentTool = state.props.tool;
+    switch (currentTool) {
+        case 'cc-0':
+            ccIconSet = ccSVG + zeroSVG;
+            break;
+        case 'cc-by':
+            ccIconSet = ccSVG + bySVG;
+            break;
+        case 'cc-by-sa':
+            ccIconSet = ccSVG + bySVG + saSVG;
+            break;
+        case 'cc-by-nd':
+            ccIconSet = ccSVG + bySVG + ndSVG;
+            break;
+        case 'cc-by-nc':
+            ccIconSet = ccSVG + bySVG + ncSVG;
+            break;
+        case 'cc-by-nc-sa':
+            ccIconSet = ccSVG + bySVG + ncSVG + saSVG;
+            break;
+        case 'cc-by-nc-nd':
+            ccIconSet = ccSVG + bySVG + ncSVG + ndSVG;
+            break;
+        default:
+            currentTool = '';
+    }
+
+    let richTextMark = attribution.title + ' © ' + attribution.workCreationYear + ' by ' + attribution.creator + ' is ' + typeAsVerb  + ' ' + '<a href="#">' + state.props.toolShort + '</a>' + ccIconSet;
     document.querySelector('#mark-your-work .rich-text.mark').innerHTML = richTextMark;
 
 

--- a/src/style.css
+++ b/src/style.css
@@ -125,3 +125,12 @@ ol li:has(.disable) {
 .help {
     display: none;
 }
+
+
+.panel {
+    display: none;
+}
+
+.panel.expand {
+    display: initial;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -116,6 +116,10 @@ ol li:has(.disable) {
     height: 1.3em;
 }
 
+.mark svg:first-of-type {
+    margin-left: .5em;
+}
+
 
 /* debug styles */
 .help {

--- a/src/style.css
+++ b/src/style.css
@@ -82,6 +82,10 @@ ol li:has(.disable) {
     display: none;
 }
 
+.hide {
+    display: none;
+}
+
 .tool header {
     display: flex;
     flex-wrap: wrap;
@@ -118,6 +122,10 @@ ol li:has(.disable) {
 
 .mark svg:first-of-type {
     margin-left: .5em;
+}
+
+.tool-rec-details input {
+    color: lightgray;
 }
 
 

--- a/src/style.css
+++ b/src/style.css
@@ -109,6 +109,13 @@ ol li:has(.disable) {
     grid-template-columns: 1fr 1fr;
 }
 
+.mark svg {
+    display: inline;
+    /* font-size: 1em; */
+    width: 1.3em;
+    height: 1.3em;
+}
+
 
 /* debug styles */
 .help {

--- a/src/style.css
+++ b/src/style.css
@@ -110,7 +110,7 @@ ol li:has(.disable) {
 .content {
     display: grid;
     gap: 2em;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr 2fr;
 }
 
 .mark svg {
@@ -126,6 +126,70 @@ ol li:has(.disable) {
 
 .tool-rec-details input {
     color: lightgray;
+}
+
+#tool-recommendation p {
+    font-size: 1.4em;
+}
+
+#mark-your-work p {
+    font-size: 1.4em;
+}
+
+details { 
+    font-family: 'Source Sans Pro';
+
+    border: 2px solid var(--vocabulary-neutral-color-lighter-gray);
+    border-radius: 5px;
+}
+
+details details {
+    margin: 1em;
+}
+
+details.medium {
+    margin-bottom: 1em;
+}
+  
+details.medium:open > summary {
+    /* margin-bottom: 1em; */
+}
+  
+details summary {
+    padding: .2em .5em;
+
+    background: var(--vocabulary-neutral-color-lighter-gray);
+    font-size: 1.6em;
+}
+
+details.format summary {
+    font-size: 1.3em;
+}
+
+  
+summary:hover {
+    cursor: pointer;
+}
+  
+summary::marker {
+    font-size: .8em;
+}
+
+details p {
+    padding: 0 1em;
+
+    font-size: 1em;
+}
+
+body.chooser-page .content {
+    grid-column: 3 / 10;
+
+}
+
+@media (max-width: 705px) {
+    .content {
+        display: block;
+    }
 }
 
 


### PR DESCRIPTION
## Description
* fixes duplicate input name error
* strip html from inputs in Attribution Details area.
* adds rough read-only fields to the Attribution Details area (trying for now, may rework or change/remove later)
* wraps the Mark formats section in `<details>`, and moves towards a collapsible section, rather than tabs more better cross-viewport UX and to simplify the implementation more (tabs don't have a native element implementation and often assume a detachment of "title" and "body" that can lead to odd semantics)
* adds baseline responsiveness to build from


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
