### PR TITLE
chore: add Docker-based Prettier integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Once changes are implemented here, they need to be updated within the `/chooser`
 
 Final production changes are deployed within vocabulary-theme Releases, updated within [`index-dev-env`][index-dev-env], and finally deployed to `index__stage` and then `index__prod` environments; going LIVE at `https://creativecommons.org/chooser`.
 
+### Code Formatting with Prettier
+
+We use [Prettier](https://prettier.io/) to enforce consistent formatting across the codebase.
+
+#### To check formatting (via Docker):
+```bash
+./docker/run-prettier.sh
 
 ## Setup
 1. open the `src/index.html` file within a browser to view the Chooser.

--- a/docker/format-prettier.sh
+++ b/docker/format-prettier.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+docker run --rm \
+  -v "$PWD":/app \
+  -w /app \
+  node:20 \
+  npx prettier . --write

--- a/docker/run-prettier.sh
+++ b/docker/run-prettier.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+docker run --rm \
+  -v "$PWD":/app \
+  -w /app \
+  node:20 \
+  npx prettier . --check

--- a/prettierignore
+++ b/prettierignore
@@ -1,0 +1,11 @@
+node_modules
+dist
+*.svg
+*.png
+*.jpg
+*.ico
+*.pdf
+*.woff
+*.woff2
+*.eot
+*.ttf

--- a/prettierrc
+++ b/prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}


### PR DESCRIPTION
## Fixes
- Fixes #520 by @dijitali 

## Description
This approach ensures consistent code formatting across environments without requiring contributors to install Prettier or Husky locally. The changes made are;
- Added `docker/run-prettier.sh` to check code formatting inside a Node container
- Added optional `docker/format-prettier.sh` script to automatically format the code
- Introduced `.prettierrc` and `.prettierignore` to configure and exclude paths
- Updated `README.md` with instructions for running Prettier via Docker

## Technical details
This avoids inconsistencies in formatting between contributors' IDEs and enforces a standard style without requiring Node-based tools like Husky or `lint-staged`, which are not part of this Python-based project.

## Tests
- Run Prettier Check
`./docker/run-prettier.sh`

- Auto-Format
`./docker/format-prettier.sh`

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
