### PR TITLE
improve stepper question clarity, correct style `label` wrapping bug

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -168,7 +168,6 @@
             <div>
                 <input type="radio" id="no-attribution" name="attribution" value="no" />
                 <label for="no-attribution">No</label>
-                <!-- <span role="tooltip">Anyone can use my work, even without giving me attribution.</span> -->
             </div>
 
         </fieldset>

--- a/src/style.css
+++ b/src/style.css
@@ -164,17 +164,8 @@
 }
 
 .chooser-page form#chooser label {
-    /* display: block; */
     font-size: .7em;
     font-weight: 400;
-}
-
-.chooser-page form#chooser span[role=tooltip] {
-    display: block;
-    font-size: .7em;
-    font-weight: 400;
-    opacity: .3;
-
 }
 
 .chooser-page form#chooser #attribution-details span {
@@ -183,6 +174,10 @@
 
     font-size: .8em;
     line-height: 1.3;
+}
+
+.chooser-page form#chooser #attribution-details label {
+    display: block;
 }
 
 .chooser-page form#chooser #attribution-details div {


### PR DESCRIPTION

## Description
- Fixes #583 
- expands the questions to be clearer, with more contextual information.
  - EX: `Attribution?` => `Require attribution for your work?`
  - This allows the answer pairings to remain straightforward and clear, by moving the contextual information to the question in a more direct way.
  - Questions are also shaped to be verb oriented to establish direct relationships with the "requirement" or "allowance" covered by a condition of a specific license trait.
- corrects a scoping bug in the CSS which forced a line break on labels in the the attribution details, but inadvertently was scoped too broad and applied that effect to every `label` in the stepper area.

# Technical Details

We'll see how this goes, we can always keep adjusting and improving how we shape this, but we will need to eventually settle on something more stable before we get into translation strings territory later.

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
