### PR TITLE
feat: add input validation for attribution details

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -573,16 +573,105 @@ function watchFieldsets(fieldsets, state) {
     });
 }
 
-function watchAttributionDetails(fieldsets, state) {
+// Validates URL format (http/https required)
+function isValidURL(url) {
+    if (!url || url.trim() === '') return true;
+    const urlPattern = /^https?:\/\/.+\..+/i;
+    return urlPattern.test(url);
+}
 
+// Validates year is 4 digits and not in the future
+function isValidYear(year) {
+    if (!year || year.trim() === '') return true;
+    const yearPattern = /^\d{4}$/;
+    if (!yearPattern.test(year)) return false;
+    const yearNum = parseInt(year, 10);
+    const currentYear = new Date().getFullYear();
+    return yearNum >= 1000 && yearNum <= currentYear;
+}
+
+// Displays error message below input field
+function showError(input, message) {
+    clearError(input);
+    input.classList.add('input-error');
+    const errorDiv = document.createElement('div');
+    errorDiv.className = 'error-message';
+    errorDiv.textContent = message;
+    errorDiv.setAttribute('role', 'alert');
+    input.parentNode.insertBefore(errorDiv, input.nextSibling);
+}
+
+// Removes error message and styling from input
+function clearError(input) {
+    input.classList.remove('input-error');
+    const nextElement = input.nextSibling;
+    if (nextElement && nextElement.classList && nextElement.classList.contains('error-message')) {
+        nextElement.remove();
+    }
+}
+
+// Validates individual input based on field type
+function validateInput(input) {
+    const inputId = input.id;
+    const value = input.value.trim();
+    clearError(input);
+    
+    if (value === '') return true;
+    
+    switch(inputId) {
+        case 'work-link':
+            if (!isValidURL(value)) {
+                showError(input, 'Please enter a valid URL starting with http:// or https:// (e.g., https://example.com)');
+                return false;
+            }
+            break;
+            
+        case 'creator-link':
+            if (!isValidURL(value)) {
+                showError(input, 'Please enter a valid URL starting with http:// or https:// (e.g., https://example.com/profile)');
+                return false;
+            }
+            break;
+            
+        case 'work-creation-year':
+            if (!isValidYear(value)) {
+                const currentYear = new Date().getFullYear();
+                showError(input, `Please enter a valid 4-digit year between 1000 and ${currentYear} (e.g., ${currentYear})`);
+                return false;
+            }
+            break;
+    }
+    
+    return true;
+}
+
+// Validates all attribution detail inputs at once
+function validateAllAttributionInputs() {
+    const inputs = document.querySelectorAll('#attribution-details input[type="text"]');
+    let allValid = true;
+    inputs.forEach(input => {
+        if (!validateInput(input)) {
+            allValid = false;
+        }
+    });
+    return allValid;
+}
+
+// Watches attribution detail inputs for validation
+function watchAttributionDetails(fieldsets, state) {
     let textFields = fieldsets[8].querySelectorAll('input');
 
     textFields.forEach((element, index) => {
-
+        element.addEventListener("blur", (event) => {
+            validateInput(element);
+        });
+        
         element.addEventListener("keyup", (event) => {
+            if (element.classList.contains('input-error')) {
+                validateInput(element);
+            }
             renderMarkingFormats(state);
         });
-
     });
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -371,3 +371,46 @@
 .chooser-page .panel.expand {
     display: initial;
 }
+
+.chooser-page .error-message {
+    display: block;
+    margin-top: .25em;
+    margin-bottom: .5em;
+    padding: .25em 0;
+    color: #d32f2f;
+    font-size: .7em;
+    line-height: 1.4;
+    animation: slideDown 0.2s ease-out;
+}
+
+.chooser-page .input-error {
+    background-color: #ffebee;
+    border: 2px solid #d32f2f !important;
+    outline: none;
+}
+
+.chooser-page .input-error:focus {
+    border-color: #b71c1c !important;
+    box-shadow: 0 0 0 2px rgba(211, 47, 47, 0.2);
+}
+
+@keyframes slideDown {
+    from {
+        opacity: 0;
+        transform: translateY(-4px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.chooser-page form#chooser #attribution-details input {
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+@media (max-width: 768px) {
+    .chooser-page .error-message {
+        font-size: .65em;
+    }
+}


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #467

## Changes
- Add URL and year validation with error messages
- Show visual feedback for invalid inputs
- Validate on blur, all fields remain optional

## Description
<!-- Concisely describe what the pull request does. -->
Adds input validation with error messages for Attribution Details fields to improve user experience and data quality.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
**scripts.js:**
- `isValidURL()` - validates URL format with regex
- `isValidYear()` - validates 4-digit year between 1000 and current year
- `showError()` / `clearError()` - manages error message display
- `validateInput()` - validates individual fields based on type
- Enhanced `watchAttributionDetails()` - adds blur and keyup event listeners

**style.css:**
- `.error-message` - styling for error text
- `.input-error` - styling for invalid input fields

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
Tested the following scenarios:
- Invalid URLs: `example.com`, `htp://bad.com`, `not a url` - shows error
- Valid URLs: `https://example.com`, `http://site.com/page` - no error
- Invalid years: `abc`, `999`, `99999`, `2026` - shows error
- Valid years: `2024`, `2000`, `1999` - no error
- Empty fields - no error (optional fields)
- Error clears when input is corrected
- Visual styling appears correctly

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
<img width="1481" height="726" alt="Screenshot 2025-11-16 at 11 04 16 AM" src="https://github.com/user-attachments/assets/a5415b92-9d1a-4f67-9d1a-ab824cdec641" />
<img width="1481" height="601" alt="Screenshot 2025-11-16 at 11 06 39 AM" src="https://github.com/user-attachments/assets/05ecdd64-a8ad-4361-9099-aff4cf6e20fd" />



## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI.
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
